### PR TITLE
Treat date based on OS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Maintainers
+* @adobe/ethos

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ demo.run: ## Run demo
 
 ci: local-test e2e-tests clean ## Run CI
 
+# PUBLISH
+# -----------
+publish: ## Release a new version
+	@goreleaser release --rm-dist
+
 # CLEANUP
 # -----------
 clean: ## Clean up local testing environment

--- a/internal/testing/cluster_upgrade.sh
+++ b/internal/testing/cluster_upgrade.sh
@@ -7,9 +7,19 @@ echo "K8S_SHREDDER: Simulating cluster upgrade..."
 echo "K8S_SHREDDER: Cordoning and labelling k8s-shredder-worker as parked with a TTL of 1 minute!"
 kubectl cordon "${K8S_CLUSTER_NAME}-worker" --kubeconfig=kubeconfig
 kubectl label node "${K8S_CLUSTER_NAME}-worker" --kubeconfig=kubeconfig shredder.ethos.adobe.net/upgrade-status=parked --overwrite=true
-kubectl label node "${K8S_CLUSTER_NAME}-worker" --kubeconfig=kubeconfig --overwrite shredder.ethos.adobe.net/parked-node-expires-on="$(date -v '+1M' -u +'%s')"
 
-# For moving node back as active, useful during debug processs
+# date is not a bash builtin. It is a system utility and that is something on which OSX and Linux differ.
+# OSX uses BSD tools while Linux uses GNU tools. They are similar but not the same.
+if [[ "$(uname)" = Linux ]]
+then
+  EXPIRES_ON=$(date -d '+1 minutes' +"%s")
+else
+  EXPIRES_ON=$(date -v '+1M' -u +'%s')
+fi
+
+kubectl label node "${K8S_CLUSTER_NAME}-worker" --kubeconfig=kubeconfig --overwrite shredder.ethos.adobe.net/parked-node-expires-on="${EXPIRES_ON}"
+
+# For moving node back as active, useful during debug process
 #export K8S_CLUSTER_NAME=k8s-shredder-test-cluster
 #kubectl uncordon "${K8S_CLUSTER_NAME}-worker" --kubeconfig=kubeconfig
 #kubectl label node "${K8S_CLUSTER_NAME}-worker" --kubeconfig=kubeconfig shredder.ethos.adobe.net/upgrade-status-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`date` is not a bash builtin. It is a system utility and that is something on which OSX and Linux differ. OSX uses BSD tools while Linux uses GNU tools. They are similar but not the same.

CI was failing because it is running on ubuntu while the initial validation were done on MacOS.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
