### PR TITLE
Fix hot reload bug and address gosec CWE

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,6 @@ var (
 	cfg                          config.Config
 	appContext                   *utils.AppContext
 	scheduler                    *gocron.Scheduler
-	configChangeCallback         func()
 
 	rootCmd = &cobra.Command{
 		Use:              "k8s-shredder",
@@ -122,12 +121,10 @@ func discoverConfig() {
 	viper.WatchConfig()
 	viper.OnConfigChange(func(e fsnotify.Event) {
 		log.Infof("Configuration file `%s` changed, attempting to reload", e.Name)
-		if configChangeCallback != nil {
-			reset()
-			parseConfig()
-			configChangeCallback()
-			run(&cobra.Command{}, []string{})
-		}
+		reset()
+		parseConfig()
+		appContext.Config = cfg
+		run(&cobra.Command{}, []string{})
 	})
 }
 

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -14,6 +14,7 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -63,8 +64,13 @@ func serve(port int) error {
 		}
 	})
 
+	server := &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+
 	go func() {
-		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+		log.Fatal(server.ListenAndServe(), nil)
 	}()
 	return nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fix the G114 gosec CWE:
```
G114 (CWE): Use of net/http serve function that has no support for setting timeouts (Confidence: HIGH, Severity: MEDIUM)
```

- Fix a bug in the hot reload functionality when shredder configmap might be changed on the flight.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
