### PR TITLE
Fix a bug where unixtime with nanosec could not be parsed

### DIFF
--- a/internal/testing/cluster_upgrade.sh
+++ b/internal/testing/cluster_upgrade.sh
@@ -12,9 +12,9 @@ kubectl label node "${K8S_CLUSTER_NAME}-worker" --kubeconfig=kubeconfig shredder
 # OSX uses BSD tools while Linux uses GNU tools. They are similar but not the same.
 if [[ "$(uname)" = Linux ]]
 then
-  EXPIRES_ON=$(date -d '+1 minutes' +"%s")
+  EXPIRES_ON=$(date -d '+1 minutes' +"%s".000)
 else
-  EXPIRES_ON=$(date -v '+1M' -u +'%s')
+  EXPIRES_ON=$(date -v '+1M' -u +'%s'.000)
 fi
 
 kubectl label node "${K8S_CLUSTER_NAME}-worker" --kubeconfig=kubeconfig --overwrite shredder.ethos.adobe.net/parked-node-expires-on="${EXPIRES_ON}"

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -76,9 +76,9 @@ func PodHasLabel(pod v1.Pod, key string) bool {
 
 // GetParkedNodeExpiryTime get the time a parked node TTL expires
 func GetParkedNodeExpiryTime(node v1.Node, expiresOnLabel string) (time.Time, error) {
-	i, err := strconv.ParseInt(node.Labels[expiresOnLabel], 10, 64)
+	i, err := strconv.ParseFloat(node.Labels[expiresOnLabel], 64)
 	if err != nil {
 		return time.Now().UTC(), errors.Errorf("Failed to parse label %s with value %s", expiresOnLabel, node.Labels[expiresOnLabel])
 	}
-	return time.Unix(i, 0).UTC(), nil
+	return time.Unix(int64(i), 0).UTC(), nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix a bug where unixtime with nanosec could not be parsed

```
time="2022-10-06T06:47:50Z" level=error msg="Failed to parse label shredder.ethos.adobe.net/parked-node-expires-on with value 1665339176.136398" dryRun=false
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
