### PR TITLE
Support Argo Rollout controller object as a first class citizen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 NAME ?= adobe/k8s-shredder
 K8S_SHREDDER_VERSION ?= "dev"
-KINDNODE_VERSION ?= "v1.28.0"
+KINDNODE_VERSION ?= "v1.30.4"
 COMMIT ?= $(shell git rev-parse --short HEAD)
 TEST_CLUSTERNAME ?= "k8s-shredder-test-cluster"
 

--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: aneci@adobe.com
   url: https://adobe.com
 
-version: 0.1.1
-appVersion: v0.2.2
+version: 0.1.0
+appVersion: v0.2.1

--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: aneci@adobe.com
   url: https://adobe.com
 
-version: 0.1.0
-appVersion: v0.2.1
+version: 0.1.1
+appVersion: v0.2.2

--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: aneci@adobe.com
   url: https://adobe.com
 
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.2.1

--- a/charts/k8s-shredder/templates/cluster-role.yaml
+++ b/charts/k8s-shredder/templates/cluster-role.yaml
@@ -15,4 +15,7 @@ rules:
 - apiGroups: [apps, extensions]
   resources: [statefulsets, deployments, replicasets]
   verbs: [get, list, watch, update, patch]
+- apiGroups: [ "argoproj.io" ]
+  resources: [ rollouts ]
+  verbs: [ get, list, watch, update, patch ]
 {{ end }}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,6 +114,7 @@ func discoverConfig() {
 	viper.SetDefault("RestartedAtAnnotation", "shredder.ethos.adobe.net/restartedAt")
 	viper.SetDefault("AllowEvictionLabel", "shredder.ethos.adobe.net/allow-eviction")
 	viper.SetDefault("ToBeDeletedTaint", "ToBeDeletedByClusterAutoscaler")
+	viper.SetDefault("ArgoRolloutsAPIVersion", "v1alpha1")
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -144,6 +145,7 @@ func parseConfig() {
 		"RestartedAtAnnotation":              cfg.RestartedAtAnnotation,
 		"AllowEvictionLabel":                 cfg.AllowEvictionLabel,
 		"ToBeDeletedTaint":                   cfg.ToBeDeletedTaint,
+		"ArgoRolloutsAPIVersion":             cfg.ArgoRolloutsAPIVersion,
 	}).Info("Loaded configuration")
 }
 

--- a/internal/testing/local_env_prep.sh
+++ b/internal/testing/local_env_prep.sh
@@ -41,8 +41,16 @@ kubectl apply -f "${test_dir}/k8s-shredder.yaml"
 echo "KIND: deploying prometheus..."
 kubectl apply -f "${test_dir}/prometheus_stuffs.yaml"
 
+echo "KIND: deploying Argo Rollouts CRD..."
+kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/rollout-crd.yaml
+
 echo "KIND: deploying test applications..."
 kubectl apply -f "${test_dir}/test_apps.yaml"
+
+# Adjust the correct UID for the test-app-argo-rollout ownerReference
+rollout_uid=$(kubectl -n ns-team-k8s-shredder-test get rollout test-app-argo-rollout -ojsonpath='{.metadata.uid}')
+cat "${test_dir}/test_apps.yaml" | sed "s/REPLACE_WITH_ROLLOUT_UID/${rollout_uid}/" | kubectl apply -f -
+
 
 echo "K8S_SHREDDER: waiting for k8s-shredder deployment to become ready!"
 retry_count=0

--- a/internal/testing/prometheus_stuffs.yaml
+++ b/internal/testing/prometheus_stuffs.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: prom/prometheus:v2.42.0
+          image: prom/prometheus:v2.54.1
           args:
             - "--storage.tsdb.retention.time=1h"
             - "--config.file=/etc/prometheus/prometheus.yml"

--- a/internal/testing/rbac.yaml
+++ b/internal/testing/rbac.yaml
@@ -31,4 +31,7 @@ rules:
   - apiGroups: [apps, extensions]
     resources: [statefulsets, deployments, replicasets]
     verbs: [get, list, watch, update, patch]
+  - apiGroups: [ "argoproj.io" ]
+    resources: [ rollouts ]
+    verbs: [ get, list, watch, update, patch ]
 

--- a/internal/testing/test_apps.yaml
+++ b/internal/testing/test_apps.yaml
@@ -240,3 +240,57 @@ spec:
   selector:
     matchLabels:
       app: test-app-statefulset
+#### FLEX ####
+# 1. Good citizen Argo Rollout in Flex world
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: test-app-argo-rollout
+  namespace: ns-team-k8s-shredder-test
+  ownerReferences:
+  - apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    blockOwnerDeletion: true
+    name: test-app-argo-rollout
+    uid: REPLACE_WITH_ROLLOUT_UID
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: test-app-argo-rollout
+  template:
+    metadata:
+      labels:
+        app: test-app-argo-rollout
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: test-app-argo-rollout
+        image: aaneci/canary
+        ports:
+        - containerPort: 8080
+          name: web
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: test-app-argo-rollout
+  namespace: ns-team-k8s-shredder-test
+spec:
+  replicas: 2
+  workloadRef:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: test-app-argo-rollout
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-app-argo-rollout
+  namespace: ns-team-k8s-shredder-test
+spec:
+  minAvailable: 10
+  selector:
+    matchLabels:
+      app: test-app-argo-rollout

--- a/internal/testing/test_apps.yaml
+++ b/internal/testing/test_apps.yaml
@@ -264,7 +264,18 @@ spec:
       labels:
         app: test-app-argo-rollout
     spec:
-      terminationGracePeriodSeconds: 10
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - test-app-argo-rollout
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: test-app-argo-rollout
         image: aaneci/canary

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,4 +33,6 @@ type Config struct {
 	AllowEvictionLabel string
 	// ToBeDeletedTaint is used for skipping a subset of parked nodes
 	ToBeDeletedTaint string
+	// ArgoRolloutsAPIVersion is used for specifying the API version from `argoproj.io` apigroup to be used while handling Argo Rollouts objects
+	ArgoRolloutsAPIVersion string
 }

--- a/pkg/utils/context.go
+++ b/pkg/utils/context.go
@@ -14,33 +14,42 @@ package utils
 import (
 	"context"
 	"github.com/adobe/k8s-shredder/pkg/config"
+	"k8s.io/client-go/dynamic"
 
 	"k8s.io/client-go/kubernetes"
 )
 
 // AppContext struct stores a context and a k8s client
 type AppContext struct {
-	Context   context.Context
-	K8sClient kubernetes.Interface
-	Config    config.Config
-	dryRun    bool
+	Context          context.Context
+	K8sClient        kubernetes.Interface
+	DynamicK8SClient dynamic.Interface
+	Config           config.Config
+	dryRun           bool
 }
 
 // NewAppContext creates a new AppContext object
 func NewAppContext(cfg config.Config, dryRun bool) (*AppContext, error) {
-	clientSet, err := getClusterConfig()
+	client, err := getK8SClient()
 	if err != nil {
 		return nil, err
 	}
+
+	dynamicClient, err := getDynamicK8SClient()
+	if err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go HandleOsSignals(cancel)
 
 	return &AppContext{
-		Context:   ctx,
-		K8sClient: clientSet,
-		Config:    cfg,
-		dryRun:    dryRun,
+		Context:          ctx,
+		K8sClient:        client,
+		DynamicK8SClient: dynamicClient,
+		Config:           cfg,
+		dryRun:           dryRun,
 	}, nil
 }
 

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -14,24 +14,40 @@ package utils
 import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"strconv"
 	"time"
 )
 
-func getClusterConfig() (*kubernetes.Clientset, error) {
+func getK8SClient() (*kubernetes.Clientset, error) {
 	cfg, err := config.GetConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	clientSet, err := kubernetes.NewForConfig(cfg)
+	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return clientSet, nil
+	return client, nil
+}
+
+func getDynamicK8SClient() (*dynamic.DynamicClient, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a dynamic client
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Errorf("Error creating dynamic client: %v", err)
+	}
+
+	return dynamicClient, nil
 }
 
 // NodeHasTaint check if a node has a taint set


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Initially, we naively thought that if a pod is managed by a replicaset, then that replicaset is managed by a deployment object.
This is no longer the case, since objects like Argo Rollouts are also leveraging the replicaset objects to handle pods.

This PR adds support for Argo Rollout controller object as a first class citizen in shredder, and adjust their `spec.restartAt` filed setting when a rollout restart is identified as needed by k8s-shredder. See https://argo-rollouts.readthedocs.io/en/stable/features/restart/#restarting-rollout-pods for more details.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
