### PR TITLE
Fix flaky e2e test and add support for enabling apiserver debug logs during testing

### DIFF
--- a/internal/testing/rbac.yaml
+++ b/internal/testing/rbac.yaml
@@ -34,4 +34,32 @@ rules:
   - apiGroups: [ "argoproj.io" ]
     resources: [ rollouts ]
     verbs: [ get, list, watch, update, patch ]
-
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edit-debug-flags-v
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/proxy
+  verbs:
+  - update
+- nonResourceURLs:
+  - /debug/flags/v
+  verbs:
+  - put
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edit-debug-flags-v
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit-debug-flags-v
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default

--- a/internal/testing/test_apps.yaml
+++ b/internal/testing/test_apps.yaml
@@ -266,16 +266,14 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - test-app-argo-rollout
-              topologyKey: kubernetes.io/hostname
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - test-app-argo-rollout
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: test-app-argo-rollout
         image: aaneci/canary


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There seems to be a race condition inside the apiserver where k8s-shredder is able to evict pods even if the pdb wouldn't allow soft evictions.

Not sure if it is related to the kind cluster or a real issue inside the apiserver codebase. 

This PR adds an extra check to make sure that the PDB status associated with the rollout object is properly populated.

This PR also adds support to enabled apiserver debug logs during trubleshooting by using the `ENABLE_APISERVER_DEBUG` env var.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
