### PR TITLE
Helm chart v0.2.0 to take advantage of k8s-shredder v0.3.0

### DIFF
--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: k8s-shredder
 
-description: K8s-shredder introduces the concept of parked nodes which aims to address some critical aspects on a Kubernetes cluster while rotating the worker nodes during a cluster upgrade.
+description: a novel way of dealing with kubernetes nodes blocked from draining
 
 type: application
 
@@ -11,6 +11,9 @@ maintainers:
 - name: adriananeci
   email: aneci@adobe.com
   url: https://adobe.com
+- name: sfotony
+  email: gosselin@adobe.com
+  url: https://adobe.com
 
-version: 0.1.2
-appVersion: v0.2.2
+version: 0.2.0
+appVersion: v0.3.0

--- a/charts/k8s-shredder/README.md
+++ b/charts/k8s-shredder/README.md
@@ -1,8 +1,8 @@
 # k8s-shredder
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
 
-K8s-shredder introduces the concept of parked nodes which aims to address some critical aspects on a Kubernetes cluster while rotating the worker nodes during a cluster upgrade.
+a novel way of dealing with kubernetes nodes blocked from draining
 
 **Homepage:** <https://github.com/adobe/k8s-shredder>
 
@@ -11,55 +11,71 @@ K8s-shredder introduces the concept of parked nodes which aims to address some c
 | Name | Email | Url |
 | ---- | ------ | --- |
 | adriananeci | <aneci@adobe.com> | <https://adobe.com> |
+| sfotony | <gosselin@adobe.com> | <https://adobe.com> |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| additionalContainers | list | `[]` |  |
-| affinity | object | `{}` |  |
-| deploymentStrategy | object | `{}` |  |
-| dryRun | bool | `false` |  |
-| environmentVars | list | `[]` |  |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `"ghcr.io/adobe/k8s-shredder"` |  |
-| imagePullSecrets | list | `[]` |  |
-| initContainers | list | `[]` |  |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
-| podMonitor.enabled | bool | `false` |  |
-| podMonitor.honorLabels | bool | `true` |  |
-| podMonitor.interval | string | `"60s"` |  |
-| podMonitor.labels | object | `{}` |  |
-| podMonitor.relabelings | list | `[]` |  |
-| podMonitor.scrapeTimeout | string | `"10s"` |  |
-| podSecurityContext | object | `{}` |  |
-| priorityClassName | string | `"system-cluster-critical"` |  |
-| rbac.create | bool | `true` |  |
-| replicaCount | int | `1` |  |
-| resources.limits.cpu | string | `"1"` |  |
-| resources.limits.memory | string | `"1Gi"` |  |
-| resources.requests.cpu | string | `"250m"` |  |
-| resources.requests.memory | string | `"250Mi"` |  |
-| securityContext | object | `{}` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `"k8s-shredder"` |  |
-| shredder.AllowEvictionLabel | string | `"shredder.ethos.adobe.net/allow-eviction"` |  |
-| shredder.EvictionLoopInterval | string | `"1h"` |  |
-| shredder.ExpiresOnLabel | string | `"shredder.ethos.adobe.net/parked-node-expires-on"` |  |
-| shredder.NamespacePrefixSkipInitialEviction | string | `"ns-ethos-"` |  |
-| shredder.ParkedNodeTTL | string | `"168h"` |  |
-| shredder.RestartedAtAnnotation | string | `"shredder.ethos.adobe.net/restartedAt"` |  |
-| shredder.RollingRestartThreshold | float | `0.1` |  |
-| shredder.ToBeDeletedTaint | string | `"ToBeDeletedByClusterAutoscaler"` |  |
-| shredder.UpgradeStatusLabel | string | `"shredder.ethos.adobe.net/upgrade-status"` |  |
-| tolerations | list | `[]` |  |
-| topologySpreadConstraints | list | `[]` |  |
-| volumes | list | `[]` |  |
+| additionalContainers | list | `[]` | Additional containers to run alongside k8s-shredder in the same pod |
+| affinity | object | `{}` | Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity) |
+| deploymentStrategy | object | `{}` | Deployment strategy for rolling updates (e.g., RollingUpdate, Recreate) |
+| dryRun | bool | `false` | Enable dry-run mode - when true, k8s-shredder will log actions but not execute them |
+| environmentVars | list | `[]` | Additional environment variables to set in the container |
+| fullnameOverride | string | `""` | Override the full name used for resources |
+| image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io/adobe/k8s-shredder"}` | Container image configuration |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy - IfNotPresent, Always, or Never |
+| image.registry | string | `"ghcr.io/adobe/k8s-shredder"` | Container registry where the k8s-shredder image is hosted |
+| imagePullSecrets | list | `[]` | Secrets for pulling images from private registries |
+| initContainers | list | `[]` | Init containers to run before the main k8s-shredder container starts |
+| logFormat | string | `"text"` | Log output format: text (human-readable) or json (structured logging) |
+| logLevel | string | `"debug"` | Available log levels: panic, fatal, error, warn, warning, info, debug, trace |
+| nameOverride | string | `""` | Override the name of the chart |
+| nodeSelector | object | `{}` | Node selector to constrain pod scheduling to specific nodes |
+| podAnnotations | object | `{}` | Annotations to add to k8s-shredder pod(s) |
+| podLabels | object | `{}` | Additional labels to add to k8s-shredder pod(s) |
+| podMonitor | object | `{"enabled":false,"honorLabels":true,"interval":"60s","labels":{},"relabelings":[],"scrapeTimeout":"10s"}` | Prometheus monitoring configuration |
+| podMonitor.enabled | bool | `false` | Enable creation of a PodMonitor resource for Prometheus scraping |
+| podMonitor.honorLabels | bool | `true` | Whether to honor labels from the target |
+| podMonitor.interval | string | `"60s"` | How often Prometheus should scrape metrics |
+| podMonitor.labels | object | `{}` | Labels to apply to the PodMonitor resource |
+| podMonitor.relabelings | list | `[]` | Metric relabeling configuration |
+| podMonitor.scrapeTimeout | string | `"10s"` | Timeout for each scrape attempt |
+| podSecurityContext | object | `{}` | Security context applied to the entire pod |
+| priorityClassName | string | `"system-cluster-critical"` | Priority class for pod scheduling - system-cluster-critical ensures high priority |
+| rbac | object | `{"create":true}` | RBAC (Role-Based Access Control) configuration |
+| rbac.create | bool | `true` | Create RBAC resources (ClusterRole, ClusterRoleBinding) |
+| replicaCount | int | `1` | Number of k8s-shredder pods to run |
+| resources | object | `{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":"250m","memory":"250Mi"}}` | Resource requests and limits for the k8s-shredder container |
+| resources.limits.cpu | string | `"1"` | Maximum CPU cores the container can use |
+| resources.limits.memory | string | `"1Gi"` | Maximum memory the container can use |
+| resources.requests.cpu | string | `"250m"` | CPU cores requested for the container (guaranteed allocation) |
+| resources.requests.memory | string | `"250Mi"` | Memory requested for the container (guaranteed allocation) |
+| securityContext | object | `{}` | Security context applied to the k8s-shredder container |
+| serviceAccount | object | `{"annotations":{},"create":true,"name":"k8s-shredder"}` | Kubernetes service account configuration |
+| serviceAccount.annotations | object | `{}` | Additional annotations for the service account (useful for IAM roles, etc.) |
+| serviceAccount.create | bool | `true` | Create a service account for k8s-shredder |
+| serviceAccount.name | string | `"k8s-shredder"` | Name of the service account |
+| shredder | object | `{"AllowEvictionLabel":"shredder.ethos.adobe.net/allow-eviction","ArgoRolloutsAPIVersion":"v1alpha1","EnableKarpenterDriftDetection":false,"EnableNodeLabelDetection":false,"EvictionLoopInterval":"1h","ExpiresOnLabel":"shredder.ethos.adobe.net/parked-node-expires-on","NamespacePrefixSkipInitialEviction":"ns-ethos-","NodeLabelsToDetect":[],"ParkedByLabel":"shredder.ethos.adobe.net/parked-by","ParkedByValue":"k8s-shredder","ParkedNodeTTL":"168h","ParkedNodeTaint":"shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule","RestartedAtAnnotation":"shredder.ethos.adobe.net/restartedAt","RollingRestartThreshold":0.1,"ToBeDeletedTaint":"ToBeDeletedByClusterAutoscaler","UpgradeStatusLabel":"shredder.ethos.adobe.net/upgrade-status"}` | Core k8s-shredder configuration |
+| shredder.AllowEvictionLabel | string | `"shredder.ethos.adobe.net/allow-eviction"` | Label to explicitly allow eviction on specific resources |
+| shredder.ArgoRolloutsAPIVersion | string | `"v1alpha1"` | API version for Argo Rollouts integration |
+| shredder.EnableKarpenterDriftDetection | bool | `false` | Enable Karpenter drift detection for node lifecycle management |
+| shredder.EnableNodeLabelDetection | bool | `false` | Enable detection of nodes based on specific labels |
+| shredder.EvictionLoopInterval | string | `"1h"` | How often to run the main eviction loop |
+| shredder.ExpiresOnLabel | string | `"shredder.ethos.adobe.net/parked-node-expires-on"` | Label used to track when a parked node expires |
+| shredder.NamespacePrefixSkipInitialEviction | string | `"ns-ethos-"` | Namespace prefix to skip during initial eviction (useful for system namespaces) |
+| shredder.NodeLabelsToDetect | list | `[]` | List of node labels to monitor for triggering shredder actions |
+| shredder.ParkedByLabel | string | `"shredder.ethos.adobe.net/parked-by"` | Label to track which component parked a node |
+| shredder.ParkedByValue | string | `"k8s-shredder"` | Value set in the ParkedByLabel to identify k8s-shredder as the parking agent |
+| shredder.ParkedNodeTTL | string | `"168h"` | How long parked nodes should remain before being eligible for deletion (7 days default) |
+| shredder.ParkedNodeTaint | string | `"shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule"` | Taint applied to parked nodes to prevent new pod scheduling |
+| shredder.RestartedAtAnnotation | string | `"shredder.ethos.adobe.net/restartedAt"` | Annotation to track when a workload was last restarted |
+| shredder.RollingRestartThreshold | float | `0.1` | Maximum percentage of nodes that can be restarted simultaneously during rolling restarts |
+| shredder.ToBeDeletedTaint | string | `"ToBeDeletedByClusterAutoscaler"` | Taint indicating nodes scheduled for deletion by cluster autoscaler |
+| shredder.UpgradeStatusLabel | string | `"shredder.ethos.adobe.net/upgrade-status"` | Label used to track node upgrade status |
+| tolerations | list | `[]` | Tolerations to allow scheduling on nodes with specific taints |
+| topologySpreadConstraints | list | `[]` | Helps ensure high availability by spreading pods across zones/nodes |
+| volumes | list | `[]` | Additional volumes to mount in the pod |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/k8s-shredder/values.yaml
+++ b/charts/k8s-shredder/values.yaml
@@ -1,62 +1,117 @@
+# -- Container image configuration
 image:
+  # -- Container registry where the k8s-shredder image is hosted
   registry: ghcr.io/adobe/k8s-shredder
+  # -- Image pull policy - IfNotPresent, Always, or Never
   pullPolicy: IfNotPresent
 
+# -- Number of k8s-shredder pods to run
 replicaCount: 1
+# -- Deployment strategy for rolling updates (e.g., RollingUpdate, Recreate)
 deploymentStrategy: {}
 
+# -- Secrets for pulling images from private registries
 imagePullSecrets: []
+# -- Override the name of the chart
 nameOverride: ""
+# -- Override the full name used for resources
 fullnameOverride: ""
 
+# -- Additional environment variables to set in the container
 environmentVars: []
 
+# -- Enable dry-run mode - when true, k8s-shredder will log actions but not execute them
 dryRun: false
 
+# -- Logging configuration
+# -- Available log levels: panic, fatal, error, warn, warning, info, debug, trace
+logLevel: "debug"
+# -- Log output format: text (human-readable) or json (structured logging)
+logFormat: "text"
+
+# -- Core k8s-shredder configuration
 shredder:
+  # -- How often to run the main eviction loop
   EvictionLoopInterval: "1h"
-  ParkedNodeTTL: "168h"  # 7 days
+  # -- How long parked nodes should remain before being eligible for deletion (7 days default)
+  ParkedNodeTTL: "168h"
+  # -- Maximum percentage of nodes that can be restarted simultaneously during rolling restarts
   RollingRestartThreshold: 0.1
+  # -- Label used to track node upgrade status
   UpgradeStatusLabel: "shredder.ethos.adobe.net/upgrade-status"
+  # -- Label used to track when a parked node expires
   ExpiresOnLabel: "shredder.ethos.adobe.net/parked-node-expires-on"
+  # -- Namespace prefix to skip during initial eviction (useful for system namespaces)
   NamespacePrefixSkipInitialEviction: "ns-ethos-"
+  # -- Annotation to track when a workload was last restarted
   RestartedAtAnnotation: "shredder.ethos.adobe.net/restartedAt"
+  # -- Label to explicitly allow eviction on specific resources
   AllowEvictionLabel: "shredder.ethos.adobe.net/allow-eviction"
+  # -- Taint indicating nodes scheduled for deletion by cluster autoscaler
   ToBeDeletedTaint: "ToBeDeletedByClusterAutoscaler"
+  # -- API version for Argo Rollouts integration
+  ArgoRolloutsAPIVersion: "v1alpha1"
+  # -- Enable Karpenter drift detection for node lifecycle management
+  EnableKarpenterDriftDetection: false
+  # -- Label to track which component parked a node
+  ParkedByLabel: "shredder.ethos.adobe.net/parked-by"
+  # -- Value set in the ParkedByLabel to identify k8s-shredder as the parking agent
+  ParkedByValue: "k8s-shredder"
+  # -- Taint applied to parked nodes to prevent new pod scheduling
+  ParkedNodeTaint: "shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule"
+  # -- Enable detection of nodes based on specific labels
+  EnableNodeLabelDetection: false
+  # -- List of node labels to monitor for triggering shredder actions
+  NodeLabelsToDetect: []
 
+# -- RBAC (Role-Based Access Control) configuration
 rbac:
+  # -- Create RBAC resources (ClusterRole, ClusterRoleBinding)
   create: true
 
+# -- Kubernetes service account configuration
 serviceAccount:
+  # -- Create a service account for k8s-shredder
   create: true
+  # -- Name of the service account
   name: k8s-shredder
+  # -- Additional annotations for the service account (useful for IAM roles, etc.)
   annotations: {}
 
-# Annotations for k8s-shredder pod(s).
+# -- Annotations to add to k8s-shredder pod(s)
 podAnnotations: {}
 
-# Additional labels for the k8s-shredder pod(s).
+# -- Additional labels to add to k8s-shredder pod(s)
 podLabels: {}
 
+# -- Security context applied to the entire pod
 podSecurityContext: {}
 
+# -- Security context applied to the k8s-shredder container
 securityContext: {}
 
-# Init containers to add into the deployment template spec
+# -- Init containers to run before the main k8s-shredder container starts
 initContainers: []
 
-# Additional containers to add into the deployment template spec
+# -- Additional containers to run alongside k8s-shredder in the same pod
 additionalContainers: []
 
+# -- Resource requests and limits for the k8s-shredder container
 resources:
   limits:
+    # -- Maximum CPU cores the container can use
     cpu: "1"
+    # -- Maximum memory the container can use
     memory: 1Gi
   requests:
+    # -- CPU cores requested for the container (guaranteed allocation)
     cpu: 250m
+    # -- Memory requested for the container (guaranteed allocation)
     memory: 250Mi
 
+# -- Additional volumes to mount in the pod
 volumes: []
+# Example volume configuration:
 # - name: ca
 #   secret:
 #     secretName: k8s-shredder-ca
@@ -64,28 +119,39 @@ volumes: []
 #       - key: ca.pem
 #         path: ca.pem
 
+# -- Node selector to constrain pod scheduling to specific nodes
 nodeSelector: {}
 
+# -- Tolerations to allow scheduling on nodes with specific taints
 tolerations: []
 
+# -- Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity)
 affinity: {}
 
+# -- Prometheus monitoring configuration
 podMonitor:
+  # -- Enable creation of a PodMonitor resource for Prometheus scraping
   enabled: false
+  # -- Labels to apply to the PodMonitor resource
   labels: {}
     # app: k8s-shredder
     # subsystem: k8s-a
+  # -- How often Prometheus should scrape metrics
   interval: 60s
+  # -- Timeout for each scrape attempt
   scrapeTimeout: 10s
+  # -- Whether to honor labels from the target
   honorLabels: true
+  # -- Metric relabeling configuration
   relabelings: []
 
-# A priority class can be optionally attached to the pod spec if one is needed
+# -- Priority class for pod scheduling - system-cluster-critical ensures high priority
 priorityClassName: system-cluster-critical
 
-## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
-## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+# -- Topology spread constraints to control pod distribution across failure domains
+# -- Helps ensure high availability by spreading pods across zones/nodes
 topologySpreadConstraints: []
+  # Example configuration:
   # - maxSkew: 1
   #   topologyKey: topology.kubernetes.io/zone
   #   whenUnsatisfiable: DoNotSchedule

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/internal/testing/e2e_test.go
+++ b/internal/testing/e2e_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/pkg/utils/context.go
+++ b/pkg/utils/context.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -13,6 +13,7 @@ package utils
 
 import (
 	"context"
+
 	"github.com/adobe/k8s-shredder/pkg/config"
 	"k8s.io/client-go/dynamic"
 

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -12,13 +12,14 @@ governing permissions and limitations under the License.
 package utils
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"strconv"
-	"time"
 )
 
 func getK8SClient() (*kubernetes.Clientset, error) {

--- a/pkg/utils/signal.go
+++ b/pkg/utils/signal.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Helm chart updates to take advantage of k8s-shredder v0.3.0; year update to CR line

## Description

Updates to templates and values files (including RBAC updates) that enable usage of karpenter drift detection and node label detection features.  Rev copyright year to 2025 in relevant locations.

## Motivation and Context

See #336 for more details on this.

## How Has This Been Tested?

This has been tested with v0.3.0; results in #336

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
