### PR TITLE
Add yaml and helm-doc linting and formating support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,36 @@
+---
 # Please see the documentation for all configuration options: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-# github-actions
-- directory: "/"
-  package-ecosystem: "github-actions"
-  schedule:
-    interval: "weekly"
-    time: "09:00"
-    # Use Europe/Bucharest Standard Time (UTC +02:00)
-    timezone: "Europe/Bucharest"
-  commit-message:
-    prefix: "dependabot"
-    include: scope
-  labels:
-    - "kind/cleanup"
-    - "dependabot"
-# Go
-- directory: "/"
-  package-ecosystem: "gomod"
-  schedule:
-    interval: "weekly"
-    time: "09:00"
-    # Use Europe/Bucharest Standard Time (UTC +02:00)
-    timezone: "Europe/Bucharest"
-  commit-message:
-    prefix: "dependabot"
-    include: scope
-# TODO decide if we should enable ignore
-#  ignore:
-#    # Ignore controller-runtime as its upgraded manually.
-#    - dependency-name: "sigs.k8s.io/controller-runtime"
-#    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
-#    - dependency-name: "k8s.io/*"
-  labels:
-    - "kind/cleanup"
-    - "dependabot"
+  # github-actions
+  - directory: /
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      time: 09:00
+      # Use Europe/Bucharest Standard Time (UTC +02:00)
+      timezone: Europe/Bucharest
+    commit-message:
+      prefix: dependabot
+      include: scope
+    labels:
+      - kind/cleanup
+      - dependabot
+  # Go
+  - directory: /
+    package-ecosystem: gomod
+    schedule:
+      interval: weekly
+      time: 09:00
+      # Use Europe/Bucharest Standard Time (UTC +02:00)
+      timezone: Europe/Bucharest
+    commit-message:
+      prefix: dependabot
+      include: scope
+      # TODO decide if we should enable ignore
+      #  ignore:
+      #  # Ignore controller-runtime as its upgraded manually.
+      #    - dependency-name: "sigs.k8s.io/controller-runtime"
+      #  # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
+      #    - dependency-name: "k8s.io/*"
+    labels: [kind/cleanup, dependabot]

--- a/.github/workflows/ci-chart.yaml
+++ b/.github/workflows/ci-chart.yaml
@@ -1,49 +1,42 @@
+---
 name: Lint and Test Helm Chart
-
 on: pull_request
-
 jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Set up Helm
-      uses: azure/setup-helm@v4
-      with:
-        version: v3.12.1
-
-    # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
-    # yamllint (https://github.com/adrienverge/yamllint) which require Python
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.13'
-        check-latest: true
-
-    - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.7.0
-
-    - name: Run chart-testing (list-changed)
-      id: list-changed
-      run: |
-        changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
-        if [[ -n "$changed" ]]; then
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-        fi
-    - name: Run chart-testing (lint)
-      if: steps.list-changed.outputs.changed == 'true'
-      run: ct lint --target-branch ${{ github.event.repository.default_branch }}
-
-    - name: Create kind cluster
-      if: steps.list-changed.outputs.changed == 'true'
-      uses: helm/kind-action@v1.12.0
-      with:
-        version: v0.29.0
-
-    - name: Run chart-testing (install)
-      if: steps.list-changed.outputs.changed == 'true'
-      run: ct install --target-branch ${{ github.event.repository.default_branch }}
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.12.1
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          check-latest: true
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.12.0
+        with:
+          version: v0.29.0
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,6 @@
+---
 name: CI tests
-
 on: pull_request
-
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -22,7 +21,7 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           # version: v1.46
-           args: -v --timeout 5m --no-config ./...
+          args: -v --timeout 5m --no-config ./...
       - name: Install k8s Kind Cluster
         uses: helm/kind-action@v1.12.0
         with:

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,27 +1,23 @@
+---
 name: Release Charts
-
 on:
   push:
-    branches:
-    - main
-
+    branches: [main]
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Configure Git
-      run: |
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-    - name: Run chart-releaser
-      uses: helm/chart-releaser-action@v1.7.0
-      env:
-        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        CR_SKIP_EXISTING: true
-        CR_RELEASE_NAME_TEMPLATE: "Helm-Chart-v{{ .Version }}"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CR_SKIP_EXISTING: true
+          CR_RELEASE_NAME_TEMPLATE: Helm-Chart-v{{ .Version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,42 +1,39 @@
+---
 name: release
-
 on:
   push:
-    tags:
-    - 'v*'
-
+    tags: [v*]
 permissions:
-  contents: write # needed to write releases
-  id-token: write # needed for keyless signing
-  packages: write # needed for ghcr access
-
+  contents: write  # needed to write releases
+  id-token: write  # needed for keyless signing
+  packages: write  # needed for ghcr access
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # this is important, otherwise it won't checkout the full tree (i.e. no previous tags)
-    - # Add support for more platforms with QEMU (optional)
-      # https://github.com/docker/setup-qemu-action
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.24'
-        cache: true
-    - uses: sigstore/cosign-installer@v3.9.0         # installs cosign
-#    - uses: anchore/sbom-action/download-syft@v0.14.1 # installs syft
-    - uses: docker/login-action@v3                   # login to ghcr
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - uses: goreleaser/goreleaser-action@v6          # run goreleaser
-      with:
-        version: latest
-        args: release --clean
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # this is important, otherwise it won't checkout the full tree (i.e. no previous tags)
+        # Add support for more platforms with QEMU (optional)
+        # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+      - uses: sigstore/cosign-installer@v3.9.0  # installs cosign
+        #    - uses: anchore/sbom-action/download-syft@v0.14.1  # installs syft
+      - uses: docker/login-action@v3  # login to ghcr
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: goreleaser/goreleaser-action@v6  # run goreleaser
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,94 +1,82 @@
+---
 version: 2
-
 project_name: k8s-shredder
-
 release:
   github:
     owner: adobe
     name: k8s-shredder
 builds:
   - id: k8s-shredder
-    goos:
-      - linux
-      - windows
-      - darwin
-    goarch:
-      - amd64
-      - "386"
-      - arm64
-    env:
-      - CGO_ENABLED=0
+    goos: [linux, windows, darwin]
+    goarch: [amd64, '386', arm64]
+    env: [CGO_ENABLED=0]
     main: .
     ldflags:
-      - -s -w -X github.com/adobe/k8s-shredder/cmd.buildVersion=v{{.Version}} -X github.com/adobe/k8s-shredder/cmd.gitSHA={{.Commit}} -X github.com/adobe/k8s-shredder/cmd.buildTime={{.Date}}
-    flags:
-      - -trimpath
+      - -s -w -X github.com/adobe/k8s-shredder/cmd.buildVersion=v{{.Version}} -X github.com/adobe/k8s-shredder/cmd.gitSHA={{.Commit}}
+        -X github.com/adobe/k8s-shredder/cmd.buildTime={{.Date}}
+    flags: [-trimpath]
     binary: k8s-shredder
-
 # signs the checksum file
 # all files (including the sboms) are included in the checksum, so we don't need to sign each one if we don't want to
 # https://goreleaser.com/customization/sign
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
-    certificate: '${artifact}.pem'
+    env: [COSIGN_EXPERIMENTAL=1]
+    certificate: ${artifact}.pem
     args:
       - sign-blob
-      - '--output-certificate=${certificate}'
-      - '--output-signature=${signature}'
-      - '${artifact}'
-      - "--yes" # needed on cosign 2.0.0+
+      - --output-certificate=${certificate}
+      - --output-signature=${signature}
+      - ${artifact}
+      - --yes  # needed on cosign 2.0.0+
     artifacts: checksum
     output: true
-
 dockers:
-  - image_templates: ["ghcr.io/adobe/{{ .ProjectName }}:v{{ .Version }}-amd64"]
+  - image_templates: ['ghcr.io/adobe/{{ .ProjectName }}:v{{ .Version }}-amd64']
     use: buildx
     dockerfile: Dockerfile
     build_flag_templates:
-    - "--platform=linux/amd64"
-    - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-    - "--label=org.opencontainers.image.description={{ .ProjectName }}"
-    - "--label=org.opencontainers.image.url=https://github.com/adobe/{{ .ProjectName }}"
-    - "--label=org.opencontainers.image.source=https://github.com/adobe/{{ .ProjectName }}"
-    - "--label=org.opencontainers.image.version=v{{ .Version }}"
-    - "--label=org.opencontainers.image.created={{ .Date }}"
-    - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-    - "--label=org.opencontainers.image.licenses=Apache-2.0"
-  - image_templates: ["ghcr.io/adobe/{{ .ProjectName }}:v{{ .Version }}-arm64v8"]
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/adobe/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/adobe/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version=v{{ .Version }}
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+  - image_templates:
+      - ghcr.io/adobe/{{ .ProjectName }}:v{{ .Version }}-arm64v8
     use: buildx
     goarch: arm64
     dockerfile: Dockerfile
     build_flag_templates:
-    - "--platform=linux/arm64/v8"
-    - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-    - "--label=org.opencontainers.image.description={{ .ProjectName }}"
-    - "--label=org.opencontainers.image.url=https://github.com/adobe/{{ .ProjectName }}"
-    - "--label=org.opencontainers.image.source=https://github.com/adobe/{{ .ProjectName }}"
-    - "--label=org.opencontainers.image.version=v{{ .Version }}"
-    - "--label=org.opencontainers.image.created={{ .Date }}"
-    - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-    - "--label=org.opencontainers.image.licenses=Apache-2.0"
+      - --platform=linux/arm64/v8
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/adobe/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/adobe/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version=v{{ .Version }}
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
 docker_manifests:
   - name_template: ghcr.io/adobe/{{.ProjectName}}:v{{.Version}}
     image_templates:
-    - ghcr.io/adobe/{{.ProjectName}}:v{{.Version}}-amd64
-    - ghcr.io/adobe/{{.ProjectName}}:v{{.Version}}-arm64v8
+      - ghcr.io/adobe/{{.ProjectName}}:v{{.Version}}-amd64
+      - ghcr.io/adobe/{{.ProjectName}}:v{{.Version}}-arm64v8
   - name_template: ghcr.io/adobe/{{.ProjectName}}:latest
     image_templates:
       - ghcr.io/adobe/{{.ProjectName}}:v{{.Version}}-amd64
       - ghcr.io/adobe/{{.ProjectName}}:v{{.Version}}-arm64v8
-
 # signs our docker image
 # https://goreleaser.com/customization/docker_sign
 docker_signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
+    env: [COSIGN_EXPERIMENTAL=1]
     artifacts: images
     output: true
     args:
-      - 'sign'
-      - '${artifact}'
-      - "--yes" # needed on cosign 2.0.0+
+      - sign
+      - ${artifact}
+      - --yes  # needed on cosign 2.0.0+

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,16 @@ lint: ## Lint go code and YAML files
 	} || { \
 		echo >&2 "[WARN] I require yamlfix but it's not installed (see https://github.com/lyz-code/yamlfix). Skipping YAML lint."; \
 	}
+	@hash kubeconform 2>/dev/null && { \
+		echo "Validating Kubernetes manifests with kubeconform..."; \
+		find internal/testing -name "*.yaml" -o -name "*.yml" | xargs kubeconform -strict -skip CustomResourceDefinition,EC2NodeClass,NodePool,Rollout,Cluster || { \
+			echo "Kubeconform found schema errors. Please fix them."; \
+			exit 1; \
+		} ; \
+		echo "Kubeconform validation OK!" ; \
+	} || { \
+		echo >&2 "[WARN] I require kubeconform but it's not installed (see https://github.com/yannh/kubeconform). Skipping kubeconform lint."; \
+	}
 	@hash helm-docs 2>/dev/null && { \
 		echo "Checking Helm documentation..."; \
 		helm-docs --chart-search-root=charts --template-files=README.md.gotmpl --dry-run >/dev/null 2>&1 || { \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default help format lint vet security build build-prereq push unit-test local-test local-test-karpenter local-test-node-labels ci clean e2e-tests check-license
+.PHONY: default help format lint vet security build build-prereq push unit-test local-test local-test-karpenter local-test-node-labels ci clean e2e-tests check-license helm-docs
 
 NAME ?= adobe/k8s-shredder
 K8S_SHREDDER_VERSION ?= "dev"
@@ -22,14 +22,21 @@ help: ## Print this help text
 
 # CI
 # -----------
-format: ## Format go code
+format: helm-docs ## Format go code and YAML files
 	@echo "Format go code..."
 	@go fmt ./...
 	@hash golangci-lint 2>/dev/null && { golangci-lint run --fix ./... ; } || { \
   		echo >&2 "[WARN] I require golangci-lint but it's not installed (see https://github.com/golangci/golangci-lint). Skipping golangci-lint format."; \
   	}
+	@hash yamlfix 2>/dev/null && { \
+		echo "Format YAML files..."; \
+		find . -name "*.yaml" -o -name "*.yml" | grep -v "/templates/" | xargs yamlfix 2>/dev/null || true ; \
+		echo "YAML files formatted!" ; \
+	} || { \
+		echo >&2 "[WARN] I require yamlfix but it's not installed (see https://github.com/lyz-code/yamlfix). Skipping YAML format."; \
+	}
 
-lint: ## Lint go code
+lint: ## Lint go code and YAML files
 	@hash golangci-lint 2>/dev/null && { \
 		echo "Checking go code style..."; \
 		echo "Run "make format" in case of failures!"; \
@@ -37,6 +44,26 @@ lint: ## Lint go code
 		echo "Go code style OK!" ; \
 	} || { \
 		echo >&2 "[WARN] I require golangci-lint but it's not installed (see https://github.com/golangci/golangci-lint). Skipping lint."; \
+	}
+	@hash yamlfix 2>/dev/null && { \
+		echo "Checking YAML files..."; \
+		find . -name "*.yaml" -o -name "*.yml" | grep -v "/templates/" | xargs yamlfix --check 2>/dev/null || { \
+			echo "YAML files have formatting issues. Run 'make format' to fix them."; \
+			exit 1; \
+		} ; \
+		echo "YAML files OK!" ; \
+	} || { \
+		echo >&2 "[WARN] I require yamlfix but it's not installed (see https://github.com/lyz-code/yamlfix). Skipping YAML lint."; \
+	}
+	@hash helm-docs 2>/dev/null && { \
+		echo "Checking Helm documentation..."; \
+		helm-docs --chart-search-root=charts --template-files=README.md.gotmpl --dry-run >/dev/null 2>&1 || { \
+			echo "Helm documentation is out of date. Run 'make format' to update it."; \
+			exit 1; \
+		} ; \
+		echo "Helm documentation OK!" ; \
+	} || { \
+		echo >&2 "[WARN] I require helm-docs but it's not installed (see https://github.com/norwoodj/helm-docs). Skipping Helm documentation lint."; \
 	}
 
 vet: ## Vetting go code
@@ -55,6 +82,15 @@ security: ## Inspects go source code for security problems
 check-license: ## Check if all go files have the license header set
 	@echo "Checking files for license header"
 	@./internal/check_license.sh
+
+helm-docs: ## Generate Helm chart documentation
+	@hash helm-docs 2>/dev/null && { \
+		echo "Generating Helm chart documentation..."; \
+		helm-docs --chart-search-root=charts --template-files=README.md.gotmpl ; \
+		echo "Helm documentation generated!" ; \
+	} || { \
+		echo >&2 "[WARN] I require helm-docs but it's not installed (see https://github.com/norwoodj/helm-docs). Skipping documentation generation."; \
+	}
 
 build: check-license lint vet security unit-test ## Builds the local Docker container for development
 	@CGO_ENABLED=0 GOOS=linux go build \

--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -1,19 +1,16 @@
+---
 apiVersion: v2
 name: k8s-shredder
-
 description: a novel way of dealing with kubernetes nodes blocked from draining
-
 type: application
-
 home: https://github.com/adobe/k8s-shredder
 icon: https://raw.githubusercontent.com/adobe/k8s-shredder/main/docs/k8s-shredder_logo.jpg
 maintainers:
-- name: adriananeci
-  email: aneci@adobe.com
-  url: https://adobe.com
-- name: sfotony
-  email: gosselin@adobe.com
-  url: https://adobe.com
-
+  - name: adriananeci
+    email: aneci@adobe.com
+    url: https://adobe.com
+  - name: sfotony
+    email: gosselin@adobe.com
+    url: https://adobe.com
 version: 0.2.0
 appVersion: v0.3.0

--- a/charts/k8s-shredder/values.yaml
+++ b/charts/k8s-shredder/values.yaml
@@ -1,74 +1,67 @@
+---
 # -- Container image configuration
 image:
   # -- Container registry where the k8s-shredder image is hosted
   registry: ghcr.io/adobe/k8s-shredder
   # -- Image pull policy - IfNotPresent, Always, or Never
   pullPolicy: IfNotPresent
-
 # -- Number of k8s-shredder pods to run
 replicaCount: 1
 # -- Deployment strategy for rolling updates (e.g., RollingUpdate, Recreate)
 deploymentStrategy: {}
-
 # -- Secrets for pulling images from private registries
 imagePullSecrets: []
 # -- Override the name of the chart
-nameOverride: ""
+nameOverride: ''
 # -- Override the full name used for resources
-fullnameOverride: ""
-
+fullnameOverride: ''
 # -- Additional environment variables to set in the container
 environmentVars: []
-
 # -- Enable dry-run mode - when true, k8s-shredder will log actions but not execute them
 dryRun: false
-
 # -- Logging configuration
 # -- Available log levels: panic, fatal, error, warn, warning, info, debug, trace
-logLevel: "debug"
+logLevel: debug
 # -- Log output format: text (human-readable) or json (structured logging)
-logFormat: "text"
-
+logFormat: text
 # -- Core k8s-shredder configuration
 shredder:
   # -- How often to run the main eviction loop
-  EvictionLoopInterval: "1h"
+  EvictionLoopInterval: 1h
   # -- How long parked nodes should remain before being eligible for deletion (7 days default)
-  ParkedNodeTTL: "168h"
+  ParkedNodeTTL: 168h
   # -- Maximum percentage of nodes that can be restarted simultaneously during rolling restarts
   RollingRestartThreshold: 0.1
   # -- Label used to track node upgrade status
-  UpgradeStatusLabel: "shredder.ethos.adobe.net/upgrade-status"
+  UpgradeStatusLabel: shredder.ethos.adobe.net/upgrade-status
   # -- Label used to track when a parked node expires
-  ExpiresOnLabel: "shredder.ethos.adobe.net/parked-node-expires-on"
+  ExpiresOnLabel: shredder.ethos.adobe.net/parked-node-expires-on
   # -- Namespace prefix to skip during initial eviction (useful for system namespaces)
-  NamespacePrefixSkipInitialEviction: "ns-ethos-"
+  NamespacePrefixSkipInitialEviction: ns-ethos-
   # -- Annotation to track when a workload was last restarted
-  RestartedAtAnnotation: "shredder.ethos.adobe.net/restartedAt"
+  RestartedAtAnnotation: shredder.ethos.adobe.net/restartedAt
   # -- Label to explicitly allow eviction on specific resources
-  AllowEvictionLabel: "shredder.ethos.adobe.net/allow-eviction"
+  AllowEvictionLabel: shredder.ethos.adobe.net/allow-eviction
   # -- Taint indicating nodes scheduled for deletion by cluster autoscaler
-  ToBeDeletedTaint: "ToBeDeletedByClusterAutoscaler"
+  ToBeDeletedTaint: ToBeDeletedByClusterAutoscaler
   # -- API version for Argo Rollouts integration
-  ArgoRolloutsAPIVersion: "v1alpha1"
+  ArgoRolloutsAPIVersion: v1alpha1
   # -- Enable Karpenter drift detection for node lifecycle management
   EnableKarpenterDriftDetection: false
   # -- Label to track which component parked a node
-  ParkedByLabel: "shredder.ethos.adobe.net/parked-by"
+  ParkedByLabel: shredder.ethos.adobe.net/parked-by
   # -- Value set in the ParkedByLabel to identify k8s-shredder as the parking agent
-  ParkedByValue: "k8s-shredder"
+  ParkedByValue: k8s-shredder
   # -- Taint applied to parked nodes to prevent new pod scheduling
-  ParkedNodeTaint: "shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule"
+  ParkedNodeTaint: shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule
   # -- Enable detection of nodes based on specific labels
   EnableNodeLabelDetection: false
   # -- List of node labels to monitor for triggering shredder actions
   NodeLabelsToDetect: []
-
 # -- RBAC (Role-Based Access Control) configuration
 rbac:
   # -- Create RBAC resources (ClusterRole, ClusterRoleBinding)
   create: true
-
 # -- Kubernetes service account configuration
 serviceAccount:
   # -- Create a service account for k8s-shredder
@@ -77,30 +70,23 @@ serviceAccount:
   name: k8s-shredder
   # -- Additional annotations for the service account (useful for IAM roles, etc.)
   annotations: {}
-
 # -- Annotations to add to k8s-shredder pod(s)
 podAnnotations: {}
-
 # -- Additional labels to add to k8s-shredder pod(s)
 podLabels: {}
-
 # -- Security context applied to the entire pod
 podSecurityContext: {}
-
 # -- Security context applied to the k8s-shredder container
 securityContext: {}
-
 # -- Init containers to run before the main k8s-shredder container starts
 initContainers: []
-
 # -- Additional containers to run alongside k8s-shredder in the same pod
 additionalContainers: []
-
 # -- Resource requests and limits for the k8s-shredder container
 resources:
   limits:
     # -- Maximum CPU cores the container can use
-    cpu: "1"
+    cpu: '1'
     # -- Maximum memory the container can use
     memory: 1Gi
   requests:
@@ -108,7 +94,6 @@ resources:
     cpu: 250m
     # -- Memory requested for the container (guaranteed allocation)
     memory: 250Mi
-
 # -- Additional volumes to mount in the pod
 volumes: []
 # Example volume configuration:
@@ -121,21 +106,18 @@ volumes: []
 
 # -- Node selector to constrain pod scheduling to specific nodes
 nodeSelector: {}
-
 # -- Tolerations to allow scheduling on nodes with specific taints
 tolerations: []
-
 # -- Affinity rules for advanced pod scheduling (node affinity, pod affinity/anti-affinity)
 affinity: {}
-
 # -- Prometheus monitoring configuration
 podMonitor:
   # -- Enable creation of a PodMonitor resource for Prometheus scraping
   enabled: false
   # -- Labels to apply to the PodMonitor resource
   labels: {}
-    # app: k8s-shredder
-    # subsystem: k8s-a
+  # app: k8s-shredder
+  # subsystem: k8s-a
   # -- How often Prometheus should scrape metrics
   interval: 60s
   # -- Timeout for each scrape attempt
@@ -144,17 +126,15 @@ podMonitor:
   honorLabels: true
   # -- Metric relabeling configuration
   relabelings: []
-
 # -- Priority class for pod scheduling - system-cluster-critical ensures high priority
 priorityClassName: system-cluster-critical
-
 # -- Topology spread constraints to control pod distribution across failure domains
 # -- Helps ensure high availability by spreading pods across zones/nodes
 topologySpreadConstraints: []
-  # Example configuration:
-  # - maxSkew: 1
-  #   topologyKey: topology.kubernetes.io/zone
-  #   whenUnsatisfiable: DoNotSchedule
-  #   labelSelector:
-  #     matchLabels:
+# Example configuration:
+# - maxSkew: 1
+#   topologyKey: topology.kubernetes.io/zone
+#   whenUnsatisfiable: DoNotSchedule
+#   labelSelector:
+#     matchLabels:
 #       app.kubernetes.io/name=k8s-shredder

--- a/config.yaml
+++ b/config.yaml
@@ -3,35 +3,29 @@
 # See README.md for detailed description of each option
 
 # Core eviction settings
-EvictionLoopInterval: "60s"                                          # How often to run the eviction loop process
-ParkedNodeTTL: "60m"                                                 # Time a node can be parked before starting force eviction process
-RollingRestartThreshold: 0.5                                        # How much time(percentage) should pass from ParkedNodeTTL before starting the rollout restart process
-
+EvictionLoopInterval: 60s  # How often to run the eviction loop process
+ParkedNodeTTL: 60m  # Time a node can be parked before starting force eviction process
+RollingRestartThreshold: 0.5  # How much time(percentage) should pass from ParkedNodeTTL before starting the rollout restart process
 # Node and pod labeling
-UpgradeStatusLabel: "shredder.ethos.adobe.net/upgrade-status"        # Label used for identifying parked nodes
-ExpiresOnLabel: "shredder.ethos.adobe.net/parked-node-expires-on"    # Label used for identifying the TTL for parked nodes
-ParkedByLabel: "shredder.ethos.adobe.net/parked-by"                  # Label used to identify which component parked the node
-ParkedByValue: "k8s-shredder"                                        # Value to set for the ParkedByLabel
-
+UpgradeStatusLabel: shredder.ethos.adobe.net/upgrade-status  # Label used for identifying parked nodes
+ExpiresOnLabel: shredder.ethos.adobe.net/parked-node-expires-on  # Label used for identifying the TTL for parked nodes
+ParkedByLabel: shredder.ethos.adobe.net/parked-by  # Label used to identify which component parked the node
+ParkedByValue: k8s-shredder  # Value to set for the ParkedByLabel
 # Eviction behavior
-NamespacePrefixSkipInitialEviction: ""                               # For pods in namespaces having this prefix proceed directly with a rollout restart without waiting for the RollingRestartThreshold
-RestartedAtAnnotation: "shredder.ethos.adobe.net/restartedAt"        # Annotation name used to mark a controller object for rollout restart
-AllowEvictionLabel: "shredder.ethos.adobe.net/allow-eviction"        # Label used for skipping evicting pods that have explicitly set this label on false
-
+NamespacePrefixSkipInitialEviction: ''  # For pods in namespaces having this prefix proceed directly with a rollout restart without waiting for the RollingRestartThreshold
+RestartedAtAnnotation: shredder.ethos.adobe.net/restartedAt  # Annotation name used to mark a controller object for rollout restart
+AllowEvictionLabel: shredder.ethos.adobe.net/allow-eviction  # Label used for skipping evicting pods that have explicitly set this label on false
 # Node management
-ToBeDeletedTaint: "ToBeDeletedByClusterAutoscaler"                   # Node taint used for skipping a subset of parked nodes that are already handled by cluster-autoscaler
-ParkedNodeTaint: "shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule"  # Taint to apply to parked nodes in format key=value:effect
-
+ToBeDeletedTaint: ToBeDeletedByClusterAutoscaler  # Node taint used for skipping a subset of parked nodes that are already handled by cluster-autoscaler
+ParkedNodeTaint: shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule  # Taint to apply to parked nodes in format key=value:effect
 # Argo Rollouts integration
-ArgoRolloutsAPIVersion: "v1alpha1"                                   # API version from argoproj.io API group to be used while handling Argo Rollouts objects
-
+ArgoRolloutsAPIVersion: v1alpha1  # API version from argoproj.io API group to be used while handling Argo Rollouts objects
 # Karpenter integration
-EnableKarpenterDriftDetection: false                                 # Controls whether to scan for drifted Karpenter NodeClaims and automatically label their nodes
-
+EnableKarpenterDriftDetection: false  # Controls whether to scan for drifted Karpenter NodeClaims and automatically label their nodes
 # Node label detection
-EnableNodeLabelDetection: false                                      # Controls whether to scan for nodes with specific labels and automatically park them
-NodeLabelsToDetect: []                                               # List of node labels to detect. Supports both key-only and key=value formats
-  # Examples:
-  # - "maintenance"                    # Matches any node with the "maintenance" label (any value)
-  # - "upgrade=required"               # Matches nodes with label "upgrade" set to "required"
-  # - "node.example.com/park"          # Matches any node with the "node.example.com/park" label
+EnableNodeLabelDetection: false  # Controls whether to scan for nodes with specific labels and automatically park them
+NodeLabelsToDetect: []  # List of node labels to detect. Supports both key-only and key=value formats
+# Examples:
+# - "maintenance"  # Matches any node with the "maintenance" label (any value)
+# - "upgrade=required"               # Matches nodes with label "upgrade" set to "required"
+# - "node.example.com/park"  # Matches any node with the "node.example.com/park" label

--- a/internal/testing/k8s-shredder-karpenter.yaml
+++ b/internal/testing/k8s-shredder-karpenter.yaml
@@ -19,25 +19,24 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-              - key: node.kubernetes.io/role
-                operator: In
-                values:
-                - master
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: node.kubernetes.io/role
+                    operator: In
+                    values: [master]
       tolerations:
-      - key: "node-role.kubernetes.io/control-plane"
-        operator: "Exists"
-        effect: "NoSchedule"
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       serviceAccountName: k8s-shredder
       containers:
         - name: k8s-shredder
-          image: adobe/k8s-shredder:dev # replace it with a stable version
+          image: adobe/k8s-shredder:dev  # replace it with a stable version
           args:
-            - "--config=/k8s-shredder-config/config.yaml"
-            - "--metrics-port=8080"
-            - "--log-level=debug"
+            - --config=/k8s-shredder-config/config.yaml
+            - --metrics-port=8080
+            - --log-level=debug
             # For running it in dry run, without taking any real eviction actions
             # - "--dry-run"
           ports:
@@ -47,7 +46,7 @@ spec:
               cpu: 250m
               memory: 250M
             limits:
-              cpu: "1"
+              cpu: '1'
               memory: 1Gi
           volumeMounts:
             - name: k8s-shredder-config-volume
@@ -92,4 +91,4 @@ spec:
     app: k8s-shredder
   ports:
     - port: 8080
-      targetPort: 8080 
+      targetPort: 8080

--- a/internal/testing/k8s-shredder-node-labels.yaml
+++ b/internal/testing/k8s-shredder-node-labels.yaml
@@ -19,25 +19,24 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-              - key: node.kubernetes.io/role
-                operator: In
-                values:
-                - master
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: node.kubernetes.io/role
+                    operator: In
+                    values: [master]
       tolerations:
-      - key: "node-role.kubernetes.io/control-plane"
-        operator: "Exists"
-        effect: "NoSchedule"
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       serviceAccountName: k8s-shredder
       containers:
         - name: k8s-shredder
-          image: adobe/k8s-shredder:dev # replace it with a stable version
+          image: adobe/k8s-shredder:dev  # replace it with a stable version
           args:
-            - "--config=/k8s-shredder-config/config.yaml"
-            - "--metrics-port=8080"
-            - "--log-level=info"
+            - --config=/k8s-shredder-config/config.yaml
+            - --metrics-port=8080
+            - --log-level=info
             # For running it in dry run, without taking any real eviction actions
             # - "--dry-run"
           ports:
@@ -47,7 +46,7 @@ spec:
               cpu: 250m
               memory: 250M
             limits:
-              cpu: "1"
+              cpu: '1'
               memory: 1Gi
           volumeMounts:
             - name: k8s-shredder-config-volume
@@ -95,4 +94,4 @@ spec:
     app: k8s-shredder
   ports:
     - port: 8080
-      targetPort: 8080 
+      targetPort: 8080

--- a/internal/testing/k8s-shredder.yaml
+++ b/internal/testing/k8s-shredder.yaml
@@ -19,25 +19,24 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-              - key: node.kubernetes.io/role
-                operator: In
-                values:
-                - master
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: node.kubernetes.io/role
+                    operator: In
+                    values: [master]
       tolerations:
-      - key: "node-role.kubernetes.io/control-plane"
-        operator: "Exists"
-        effect: "NoSchedule"
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       serviceAccountName: k8s-shredder
       containers:
         - name: k8s-shredder
-          image: adobe/k8s-shredder:dev # replace it with a stable version
+          image: adobe/k8s-shredder:dev  # replace it with a stable version
           args:
-            - "--config=/k8s-shredder-config/config.yaml"
-            - "--metrics-port=8080"
-            - "--log-level=info"
+            - --config=/k8s-shredder-config/config.yaml
+            - --metrics-port=8080
+            - --log-level=info
             # For running it in dry run, without taking any real eviction actions
             # - "--dry-run"
           ports:
@@ -47,7 +46,7 @@ spec:
               cpu: 250m
               memory: 250M
             limits:
-              cpu: "1"
+              cpu: '1'
               memory: 1Gi
           volumeMounts:
             - name: k8s-shredder-config-volume

--- a/internal/testing/karpenter-manifests.yaml
+++ b/internal/testing/karpenter-manifests.yaml
@@ -9,24 +9,24 @@ spec:
       requirements:
         - key: kubernetes.io/arch
           operator: In
-          values: ["amd64"]
+          values: [amd64]
         - key: kubernetes.io/os
           operator: In
-          values: ["linux"]
+          values: [linux]
         - key: karpenter.sh/capacity-type
           operator: In
-          values: ["spot", "on-demand"]
+          values: [spot, on-demand]
         - key: node.kubernetes.io/instance-type
           operator: In
-          values: ["m5.large", "m5.xlarge"]
+          values: [m5.large, m5.xlarge]
       nodeClassRef:
         group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: default-nodeclass
       taints:
-        - key: "example.com/special-taint"
-          value: "special-value"
-          effect: "NoSchedule"
+        - key: example.com/special-taint
+          value: special-value
+          effect: NoSchedule
   limits:
     cpu: 1000
   disruption:
@@ -43,24 +43,24 @@ spec:
       requirements:
         - key: kubernetes.io/arch
           operator: In
-          values: ["amd64"]
+          values: [amd64]
         - key: kubernetes.io/os
           operator: In
-          values: ["linux"]
+          values: [linux]
         - key: karpenter.sh/capacity-type
           operator: In
-          values: ["spot"]
+          values: [spot]
         - key: node.kubernetes.io/instance-type
           operator: In
-          values: ["m5.large"]
+          values: [m5.large]
       nodeClassRef:
         group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: test-nodeclass
       taints:
-        - key: "example.com/test-taint"
-          value: "test-value"
-          effect: "NoSchedule"
+        - key: example.com/test-taint
+          value: test-value
+          effect: NoSchedule
   limits:
     cpu: 500
   disruption:
@@ -72,14 +72,14 @@ kind: EC2NodeClass
 metadata:
   name: default-nodeclass
 spec:
-  role: "KarpenterNodeRole-k8s-shredder-test-cluster"
+  role: KarpenterNodeRole-k8s-shredder-test-cluster
   amiFamily: AL2
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "k8s-shredder-test-cluster"
+        karpenter.sh/discovery: k8s-shredder-test-cluster
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "k8s-shredder-test-cluster"
+        karpenter.sh/discovery: k8s-shredder-test-cluster
   instanceStorePolicy: RAID0
   userData: |
     #!/bin/bash
@@ -91,16 +91,16 @@ kind: EC2NodeClass
 metadata:
   name: test-nodeclass
 spec:
-  role: "KarpenterNodeRole-k8s-shredder-test-cluster"
+  role: KarpenterNodeRole-k8s-shredder-test-cluster
   amiFamily: AL2
   subnetSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "k8s-shredder-test-cluster"
+        karpenter.sh/discovery: k8s-shredder-test-cluster
   securityGroupSelectorTerms:
     - tags:
-        karpenter.sh/discovery: "k8s-shredder-test-cluster"
+        karpenter.sh/discovery: k8s-shredder-test-cluster
   instanceStorePolicy: RAID0
-  userData: |
+  userData: |-
     #!/bin/bash
     /etc/eks/bootstrap.sh k8s-shredder-test-cluster
-    echo "NodeClass: test-nodeclass" >> /etc/kubernetes/kubelet/kubelet-config.json 
+    echo "NodeClass: test-nodeclass" >> /etc/kubernetes/kubelet/kubelet-config.json

--- a/internal/testing/kind-karpenter.yaml
+++ b/internal/testing/kind-karpenter.yaml
@@ -1,30 +1,31 @@
+---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerPort: 6444
   apiServerAddress: 0.0.0.0
 nodes:
-- role: control-plane
-  extraPortMappings:
-  - containerPort: 30007
-    hostPort: 30008
-  kubeadmConfigPatches:
-    - |
-      kind: InitConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "node.kubernetes.io/role=etcd,node.kubernetes.io/role=master"
-- role: worker
-  kubeadmConfigPatches:
-    - |
-      kind: JoinConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "node.kubernetes.io/role=worker,will-be-parked=yes"
-- role: worker
-  kubeadmConfigPatches:
-    - |
-      kind: JoinConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "node.kubernetes.io/role=worker" 
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30007
+        hostPort: 30008
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "node.kubernetes.io/role=etcd,node.kubernetes.io/role=master"
+  - role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "node.kubernetes.io/role=worker,will-be-parked=yes"
+  - role: worker
+    kubeadmConfigPatches:
+      - |-
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "node.kubernetes.io/role=worker"

--- a/internal/testing/kind-node-labels.yaml
+++ b/internal/testing/kind-node-labels.yaml
@@ -1,30 +1,31 @@
+---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerPort: 6445
   apiServerAddress: 0.0.0.0
 nodes:
-- role: control-plane
-  extraPortMappings:
-  - containerPort: 30007
-    hostPort: 30009
-  kubeadmConfigPatches:
-    - |
-      kind: InitConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "node.kubernetes.io/role=etcd,node.kubernetes.io/role=master"
-- role: worker
-  kubeadmConfigPatches:
-    - |
-      kind: JoinConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "node.kubernetes.io/role=worker"
-- role: worker
-  kubeadmConfigPatches:
-    - |
-      kind: JoinConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "node.kubernetes.io/role=worker" 
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30007
+        hostPort: 30009
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "node.kubernetes.io/role=etcd,node.kubernetes.io/role=master"
+  - role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "node.kubernetes.io/role=worker"
+  - role: worker
+    kubeadmConfigPatches:
+      - |-
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "node.kubernetes.io/role=worker"

--- a/internal/testing/kind.yaml
+++ b/internal/testing/kind.yaml
@@ -1,30 +1,31 @@
+---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerPort: 6443
   apiServerAddress: 0.0.0.0
 nodes:
-- role: control-plane
-  extraPortMappings:
-  - containerPort: 30007
-    hostPort: 30007
-  kubeadmConfigPatches:
-    - |
-      kind: InitConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "node.kubernetes.io/role=etcd,node.kubernetes.io/role=master"
-- role: worker
-  kubeadmConfigPatches:
-    - |
-      kind: JoinConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "node.kubernetes.io/role=worker,will-be-parked=yes"
-- role: worker
-  kubeadmConfigPatches:
-    - |
-      kind: JoinConfiguration
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "node.kubernetes.io/role=worker"
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30007
+        hostPort: 30007
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "node.kubernetes.io/role=etcd,node.kubernetes.io/role=master"
+  - role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "node.kubernetes.io/role=worker,will-be-parked=yes"
+  - role: worker
+    kubeadmConfigPatches:
+      - |-
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "node.kubernetes.io/role=worker"

--- a/internal/testing/prometheus_stuffs.yaml
+++ b/internal/testing/prometheus_stuffs.yaml
@@ -20,9 +20,9 @@ spec:
         - name: prometheus
           image: prom/prometheus:v2.54.1
           args:
-            - "--storage.tsdb.retention.time=1h"
-            - "--config.file=/etc/prometheus/prometheus.yml"
-            - "--storage.tsdb.path=/prometheus/"
+            - --storage.tsdb.retention.time=1h
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus/
           ports:
             - containerPort: 9090
           resources:
@@ -30,7 +30,7 @@ spec:
               cpu: 500m
               memory: 500M
             limits:
-              cpu: "1"
+              cpu: '1'
               memory: 1Gi
           volumeMounts:
             - name: prometheus-config-volume
@@ -42,7 +42,6 @@ spec:
           configMap:
             defaultMode: 420
             name: prometheus-server-conf
-
         - name: prometheus-storage-volume
           emptyDir: {}
 ---
@@ -68,11 +67,5 @@ metadata:
     name: prometheus-server-conf
   namespace: kube-system
 data:
-  prometheus.yml: |-
-    global:
-      scrape_interval: 5s
-      evaluation_interval: 5s
-    scrape_configs:      
-      - job_name: 'k8s-shredder'
-        static_configs:
-          - targets: ['k8s-shredder.kube-system.svc.cluster.local:8080']
+  prometheus.yml: "global:\n  scrape_interval: 5s\n  evaluation_interval: 5s\nscrape_configs:\
+    \      \n  - job_name: 'k8s-shredder'\n    static_configs:\n      - targets: ['k8s-shredder.kube-system.svc.cluster.local:8080']"

--- a/internal/testing/rbac.yaml
+++ b/internal/testing/rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -22,37 +23,32 @@ kind: ClusterRole
 metadata:
   name: k8s-shredder
 rules:
-  - apiGroups: ["*"]
+  - apiGroups: ['*']
     resources: [nodes]
     verbs: [get, list, watch, update, patch]
-  - apiGroups: ["*"]
+  - apiGroups: ['*']
     resources: [pods, pods/eviction]
-    verbs: ["*"]
+    verbs: ['*']
   - apiGroups: [apps, extensions]
     resources: [statefulsets, deployments, replicasets]
     verbs: [get, list, watch, update, patch]
-  - apiGroups: [ "argoproj.io" ]
-    resources: [ rollouts ]
-    verbs: [ get, list, watch, update, patch ]
-  - apiGroups: [ "karpenter.sh" ]
-    resources: [ nodeclaims ]
-    verbs: [ get, list, watch ]
+  - apiGroups: [argoproj.io]
+    resources: [rollouts]
+    verbs: [get, list, watch, update, patch]
+  - apiGroups: [karpenter.sh]
+    resources: [nodeclaims]
+    verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: edit-debug-flags-v
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes/proxy
-  verbs:
-  - update
-- nonResourceURLs:
-  - /debug/flags/v
-  verbs:
-  - put
+  - apiGroups: ['']
+    resources: [nodes/proxy]
+    verbs: [update]
+  - nonResourceURLs: [/debug/flags/v]
+    verbs: [put]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -63,6 +59,6 @@ roleRef:
   kind: ClusterRole
   name: edit-debug-flags-v
 subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: default
+  - kind: ServiceAccount
+    name: default
+    namespace: default

--- a/internal/testing/test_apps.yaml
+++ b/internal/testing/test_apps.yaml
@@ -99,7 +99,7 @@ spec:
                 matchExpressions:
                   - key: will-be-parked
                     operator: In
-                    values: [true]
+                    values: ['true']
       containers:
         - name: canary
           image: aaneci/canary

--- a/internal/testing/test_apps.yaml
+++ b/internal/testing/test_apps.yaml
@@ -1,5 +1,3 @@
-##### PAAS #####
-# 1. Good citizen with `shredder.ethos.adobe.net/allow-eviction: false`
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -20,7 +18,7 @@ spec:
     metadata:
       labels:
         app: test-app-disallow-eviction
-        shredder.ethos.adobe.net/allow-eviction: "false"
+        shredder.ethos.adobe.net/allow-eviction: 'false'
     spec:
       containers:
         - name: canary
@@ -36,7 +34,6 @@ spec:
   selector:
     matchLabels:
       app: test-app-disallow-eviction
-
 # 2. Good citizen
 ---
 apiVersion: apps/v1
@@ -73,7 +70,6 @@ spec:
   selector:
     matchLabels:
       app: test-app-allow-eviction
-
 # 3. Bad citizen with wrongly configured PDB
 ---
 apiVersion: apps/v1
@@ -103,8 +99,7 @@ spec:
                 matchExpressions:
                   - key: will-be-parked
                     operator: In
-                    values:
-                      - "yes"
+                    values: [true]
       containers:
         - name: canary
           image: aaneci/canary
@@ -119,7 +114,6 @@ spec:
   selector:
     matchLabels:
       app: test-app-with-bad-pdb
-
 # 4. Good citizen with recreate update strategy
 ---
 apiVersion: apps/v1
@@ -153,8 +147,7 @@ spec:
   selector:
     matchLabels:
       app: test-app-recreate
-
-##### CAAS #####
+##### CAAS  #####
 # 1. Good citizen in CaaS world
 ---
 apiVersion: apps/v1
@@ -215,7 +208,7 @@ spec:
   selector:
     matchLabels:
       app: test-app-statefulset
-  serviceName: "test-app-statefulset"
+  serviceName: test-app-statefulset
   replicas: 3
   template:
     metadata:
@@ -240,7 +233,7 @@ spec:
   selector:
     matchLabels:
       app: test-app-statefulset
-#### FLEX ####
+#### FLEX  ####
 # 1. Good citizen Argo Rollout in Flex world
 ---
 apiVersion: apps/v1
@@ -249,11 +242,11 @@ metadata:
   name: test-app-argo-rollout
   namespace: ns-team-k8s-shredder-test
   ownerReferences:
-  - apiVersion: argoproj.io/v1alpha1
-    kind: Rollout
-    blockOwnerDeletion: true
-    name: test-app-argo-rollout
-    uid: REPLACE_WITH_ROLLOUT_UID
+    - apiVersion: argoproj.io/v1alpha1
+      kind: Rollout
+      blockOwnerDeletion: true
+      name: test-app-argo-rollout
+      uid: REPLACE_WITH_ROLLOUT_UID
 spec:
   replicas: 2
   selector:
@@ -267,19 +260,18 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - test-app-argo-rollout
-            topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values: [test-app-argo-rollout]
+              topologyKey: kubernetes.io/hostname
       containers:
-      - name: test-app-argo-rollout
-        image: aaneci/canary
-        ports:
-        - containerPort: 8080
-          name: web
+        - name: test-app-argo-rollout
+          image: aaneci/canary
+          ports:
+            - containerPort: 8080
+              name: web
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/test_karpenter_drift.yaml
+++ b/test_karpenter_drift.yaml
@@ -1,14 +1,15 @@
+---
 EvictionLoopInterval: 30s
 ParkedNodeTTL: 1h
 RollingRestartThreshold: 0.5
-UpgradeStatusLabel: "shredder.ethos.adobe.net/upgrade-status"
-ExpiresOnLabel: "shredder.ethos.adobe.net/parked-node-expires-on"
-NamespacePrefixSkipInitialEviction: ""
-RestartedAtAnnotation: "shredder.ethos.adobe.net/restartedAt"
-AllowEvictionLabel: "shredder.ethos.adobe.net/allow-eviction"
-ToBeDeletedTaint: "ToBeDeletedByClusterAutoscaler"
-ArgoRolloutsAPIVersion: "v1alpha1"
+UpgradeStatusLabel: shredder.ethos.adobe.net/upgrade-status
+ExpiresOnLabel: shredder.ethos.adobe.net/parked-node-expires-on
+NamespacePrefixSkipInitialEviction: ''
+RestartedAtAnnotation: shredder.ethos.adobe.net/restartedAt
+AllowEvictionLabel: shredder.ethos.adobe.net/allow-eviction
+ToBeDeletedTaint: ToBeDeletedByClusterAutoscaler
+ArgoRolloutsAPIVersion: v1alpha1
 EnableKarpenterDriftDetection: true
-ParkedByLabel: "shredder.ethos.adobe.net/parked-by"
-ParkedByValue: "k8s-shredder"
-ParkedNodeTaint: "shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule" 
+ParkedByLabel: shredder.ethos.adobe.net/parked-by
+ParkedByValue: k8s-shredder
+ParkedNodeTaint: shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule


### PR DESCRIPTION
## Description

Adds yamlfix and helm-docs to the lint and format make commands.  Add kubeconform kubernetes object validation to lint command (excludes CRDs and custom objects -EC2NodeClass, NodePool, Rollout, and Cluster).  Adds a new helm-docs make command.

## Motivation and Context

This will better help flag formatting issues before they make it to PR review.

## How Has This Been Tested?

Used command to lint and format current branch, and then ran "make clean build ci" to ensure nothing broke.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
