### PR TITLE
ensure helm chart reflects all config options

### DIFF
--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -15,5 +15,5 @@ maintainers:
   email: gosselin@adobe.com
   url: https://adobe.com
 
-version: 0.2.0
-appVersion: v0.3.0
+version: 0.2.1
+appVersion: v0.3.1

--- a/charts/k8s-shredder/README.md
+++ b/charts/k8s-shredder/README.md
@@ -1,6 +1,6 @@
 # k8s-shredder
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 a novel way of dealing with kubernetes nodes blocked from draining
 

--- a/charts/k8s-shredder/templates/configmap.yaml
+++ b/charts/k8s-shredder/templates/configmap.yaml
@@ -16,3 +16,10 @@ data:
     RestartedAtAnnotation: "{{.Values.shredder.RestartedAtAnnotation}}"
     AllowEvictionLabel: "{{.Values.shredder.AllowEvictionLabel}}"
     ToBeDeletedTaint: "{{.Values.shredder.ToBeDeletedTaint}}"
+    ArgoRolloutsAPIVersion: "{{.Values.shredder.ArgoRolloutsAPIVersion}}"
+    EnableKarpenterDriftDetection: {{.Values.shredder.EnableKarpenterDriftDetection}}
+    ParkedByLabel: "{{.Values.shredder.ParkedByLabel}}"
+    ParkedByValue: "{{.Values.shredder.ParkedByValue}}"
+    ParkedNodeTaint: "{{.Values.shredder.ParkedNodeTaint}}"
+    EnableNodeLabelDetection: {{.Values.shredder.EnableNodeLabelDetection}}
+    NodeLabelsToDetect: {{.Values.shredder.NodeLabelsToDetect | toJson}}


### PR DESCRIPTION
## Description

Not all configuration options were available in helm chart configmap template; this fixes that.

## Motivation and Context

Without these configmap options, karpenter and node-label parking won't be available using the helm chart.

## How Has This Been Tested?

This is been tested in a local cluster.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
