### PR TITLE
cluster-role permissions fix

### DIFF
--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -15,5 +15,5 @@ maintainers:
   email: gosselin@adobe.com
   url: https://adobe.com
 
-version: 0.2.1
+version: 0.2.2
 appVersion: v0.3.1

--- a/charts/k8s-shredder/README.md
+++ b/charts/k8s-shredder/README.md
@@ -1,6 +1,6 @@
 # k8s-shredder
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 a novel way of dealing with kubernetes nodes blocked from draining
 

--- a/charts/k8s-shredder/templates/cluster-role.yaml
+++ b/charts/k8s-shredder/templates/cluster-role.yaml
@@ -8,7 +8,7 @@ metadata:
 rules:
 - apiGroups: ["*"]
   resources: [nodes]
-  verbs: [get, list, watch]
+  verbs: [get, list, watch, update, patch]
 - apiGroups: ["*"]
   resources: [pods, pods/eviction]
   verbs: ["*"]
@@ -18,4 +18,7 @@ rules:
 - apiGroups: [ "argoproj.io" ]
   resources: [ rollouts ]
   verbs: [ get, list, watch, update, patch ]
+- apiGroups: [ "karpenter.sh" ]
+  resources: [ nodeclaims ]
+  verbs: [ get, list, watch ]
 {{ end }}

--- a/charts/k8s-shredder/templates/deployment.yaml
+++ b/charts/k8s-shredder/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
           args:
           - "--config=/k8s-shredder-config/config.yaml"
           - "--metrics-port=8080"
+          - "--log-level={{ .Values.logLevel }}"
           {{- if .Values.dryRun }}
           - "--dry-run"
           {{- end }}
@@ -86,13 +87,29 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node.kubernetes.io/role
+                operator: In
+                values:
+                - master
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- else }}
+      tolerations:
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:


### PR DESCRIPTION
## Description

Fix a cluster-role permissions issue taht affects karpenter and node-label parking, and adds the ability to control log-level in the deployment.

## Motivation and Context

This fixes a bug that was not caught in CI because CI does not currently use the helm chart.  

## How Has This Been Tested?

This has been tested by applying the change to a cluster currently using the helm chart, and scanning the logs for errors.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
