### PR TITLE
Update local testing to use the helm chart, add kubernetes service creation to chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 # build artifacts
 kubeconfig*
 dist
-k8s-shredder
+/k8s-shredder
 my-k8s-shredder-values.yaml
 
 # Test binary, build with `go test -c`

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ build: check-license lint vet security unit-test ## Builds the local Docker cont
 local-test: build ## Test docker image in a kind cluster (with Karpenter drift and node label detection disabled)
 	@hash kind 2>/dev/null && { \
 		echo "Test docker image in a kind cluster..."; \
-		./internal/testing/local_env_prep.sh "${K8S_SHREDDER_VERSION}" "${KINDNODE_VERSION}" "${TEST_CLUSTERNAME}" "${KUBECONFIG_LOCALTEST}" && \
+		./internal/testing/local_env_prep_helm.sh "${K8S_SHREDDER_VERSION}" "${KINDNODE_VERSION}" "${TEST_CLUSTERNAME}" "${KUBECONFIG_LOCALTEST}" && \
 		./internal/testing/cluster_upgrade.sh "${TEST_CLUSTERNAME}" "${KUBECONFIG_LOCALTEST}" || \
 		exit 1; \
 	} || { \
@@ -123,7 +123,7 @@ local-test: build ## Test docker image in a kind cluster (with Karpenter drift a
 local-test-karpenter: build ## Test docker image in a kind cluster with Karpenter and drift detection enabled
 	@hash kind 2>/dev/null && { \
 		echo "Test docker image in a kind cluster with Karpenter..."; \
-		./internal/testing/local_env_prep_karpenter.sh "${K8S_SHREDDER_VERSION}" "${KINDNODE_VERSION}" "${TEST_CLUSTERNAME_KARPENTER}" "${KUBECONFIG_KARPENTER}" && \
+		./internal/testing/local_env_prep_karpenter_helm.sh "${K8S_SHREDDER_VERSION}" "${KINDNODE_VERSION}" "${TEST_CLUSTERNAME_KARPENTER}" "${KUBECONFIG_KARPENTER}" && \
 		./internal/testing/cluster_upgrade_karpenter.sh "${TEST_CLUSTERNAME_KARPENTER}" "${KUBECONFIG_KARPENTER}" || \
 		exit 1; \
 	} || { \
@@ -133,7 +133,7 @@ local-test-karpenter: build ## Test docker image in a kind cluster with Karpente
 local-test-node-labels: build ## Test docker image in a kind cluster with node label detection enabled
 	@hash kind 2>/dev/null && { \
 		echo "Test docker image in a kind cluster with node label detection..."; \
-		./internal/testing/local_env_prep_node_labels.sh "${K8S_SHREDDER_VERSION}" "${KINDNODE_VERSION}" "${TEST_CLUSTERNAME_NODE_LABELS}" "${KUBECONFIG_NODE_LABELS}" && \
+		./internal/testing/local_env_prep_node_labels_helm.sh "${K8S_SHREDDER_VERSION}" "${KINDNODE_VERSION}" "${TEST_CLUSTERNAME_NODE_LABELS}" "${KUBECONFIG_NODE_LABELS}" && \
 		./internal/testing/cluster_upgrade_node_labels.sh "${TEST_CLUSTERNAME_NODE_LABELS}" "${KUBECONFIG_NODE_LABELS}" || \
 		exit 1; \
 	} || { \
@@ -163,7 +163,7 @@ e2e-tests:  ## Run e2e tests for k8s-shredder deployed in a local kind cluster
 .PHONY: demo.prep demo.run demo.rollback
 demo.prep: build ## Setup demo cluster
 	echo "Setup demo cluster..."
-	./internal/testing/local_env_prep.sh "${K8S_SHREDDER_VERSION}" "${KINDNODE_VERSION}" "${TEST_CLUSTERNAME}"
+	./internal/testing/local_env_prep_helm.sh "${K8S_SHREDDER_VERSION}" "${KINDNODE_VERSION}" "${TEST_CLUSTERNAME}"
 
 demo.run: ## Run demo
 	./internal/testing/cluster_upgrade.sh "${TEST_CLUSTERNAME}"

--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -6,12 +6,11 @@ type: application
 home: https://github.com/adobe/k8s-shredder
 icon: https://raw.githubusercontent.com/adobe/k8s-shredder/main/docs/k8s-shredder_logo.jpg
 maintainers:
-- name: adriananeci
-  email: aneci@adobe.com
-  url: https://adobe.com
-- name: sfotony
-  email: gosselin@adobe.com
-  url: https://adobe.com
-
+  - name: adriananeci
+    email: aneci@adobe.com
+    url: https://adobe.com
+  - name: sfotony
+    email: gosselin@adobe.com
+    url: https://adobe.com
 version: 0.2.4
 appVersion: v0.3.1

--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -6,11 +6,12 @@ type: application
 home: https://github.com/adobe/k8s-shredder
 icon: https://raw.githubusercontent.com/adobe/k8s-shredder/main/docs/k8s-shredder_logo.jpg
 maintainers:
-  - name: adriananeci
-    email: aneci@adobe.com
-    url: https://adobe.com
-  - name: sfotony
-    email: gosselin@adobe.com
-    url: https://adobe.com
-version: 0.2.3
+- name: adriananeci
+  email: aneci@adobe.com
+  url: https://adobe.com
+- name: sfotony
+  email: gosselin@adobe.com
+  url: https://adobe.com
+
+version: 0.2.4
 appVersion: v0.3.1

--- a/charts/k8s-shredder/README.md
+++ b/charts/k8s-shredder/README.md
@@ -1,6 +1,6 @@
 # k8s-shredder
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.1](https://img.shields.io/badge/AppVersion-v0.3.1-informational?style=flat-square)
 
 a novel way of dealing with kubernetes nodes blocked from draining
 
@@ -52,6 +52,13 @@ a novel way of dealing with kubernetes nodes blocked from draining
 | resources.requests.cpu | string | `"250m"` | CPU cores requested for the container (guaranteed allocation) |
 | resources.requests.memory | string | `"250Mi"` | Memory requested for the container (guaranteed allocation) |
 | securityContext | object | `{}` | Security context applied to the k8s-shredder container |
+| service | object | `{"annotations":{},"create":false,"labels":{},"port":8080,"targetPort":"metrics","type":"ClusterIP"}` | Kubernetes service configuration |
+| service.annotations | object | `{}` | Additional annotations for the service |
+| service.create | bool | `false` | Create a service for k8s-shredder metrics endpoint |
+| service.labels | object | `{}` | Additional labels for the service |
+| service.port | int | `8080` | Service port for metrics endpoint |
+| service.targetPort | string | `"metrics"` | Target port for metrics endpoint |
+| service.type | string | `"ClusterIP"` | Service type (ClusterIP, NodePort, LoadBalancer) |
 | serviceAccount | object | `{"annotations":{},"create":true,"name":"k8s-shredder"}` | Kubernetes service account configuration |
 | serviceAccount.annotations | object | `{}` | Additional annotations for the service account (useful for IAM roles, etc.) |
 | serviceAccount.create | bool | `true` | Create a service account for k8s-shredder |

--- a/charts/k8s-shredder/templates/service.yaml
+++ b/charts/k8s-shredder/templates/service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.service.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "k8s-shredder.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "k8s-shredder.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+{{ include "k8s-shredder.matchLabels" . | indent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+{{- end }} 

--- a/charts/k8s-shredder/values.yaml
+++ b/charts/k8s-shredder/values.yaml
@@ -70,7 +70,6 @@ serviceAccount:
   name: k8s-shredder
   # -- Additional annotations for the service account (useful for IAM roles, etc.)
   annotations: {}
-
 # -- Kubernetes service configuration
 service:
   # -- Create a service for k8s-shredder metrics endpoint
@@ -85,7 +84,6 @@ service:
   annotations: {}
   # -- Additional labels for the service
   labels: {}
-
 # -- Annotations to add to k8s-shredder pod(s)
 podAnnotations: {}
 # -- Additional labels to add to k8s-shredder pod(s)

--- a/charts/k8s-shredder/values.yaml
+++ b/charts/k8s-shredder/values.yaml
@@ -70,6 +70,22 @@ serviceAccount:
   name: k8s-shredder
   # -- Additional annotations for the service account (useful for IAM roles, etc.)
   annotations: {}
+
+# -- Kubernetes service configuration
+service:
+  # -- Create a service for k8s-shredder metrics endpoint
+  create: false
+  # -- Service type (ClusterIP, NodePort, LoadBalancer)
+  type: ClusterIP
+  # -- Service port for metrics endpoint
+  port: 8080
+  # -- Target port for metrics endpoint
+  targetPort: metrics
+  # -- Additional annotations for the service
+  annotations: {}
+  # -- Additional labels for the service
+  labels: {}
+
 # -- Annotations to add to k8s-shredder pod(s)
 podAnnotations: {}
 # -- Additional labels to add to k8s-shredder pod(s)

--- a/internal/testing/local_env_prep_helm.sh
+++ b/internal/testing/local_env_prep_helm.sh
@@ -15,7 +15,7 @@ else
   # create a k8s cluster
   echo "KIND: creating cluster ${K8S_CLUSTER_NAME} with version ${KINDNODE_VERSION}..."
   kind create cluster --name "${K8S_CLUSTER_NAME}" --kubeconfig=${KUBECONFIG_FILE} --image "kindest/node:${KINDNODE_VERSION}" \
-      --config "${test_dir}/kind-node-labels.yaml"
+      --config "${test_dir}/kind.yaml"
   export KUBECONFIG=${KUBECONFIG_FILE}
 fi
 
@@ -33,9 +33,6 @@ else
   kubectl create namespace ns-team-k8s-shredder-test
 fi
 
-echo "KIND: setting up k8s-shredder rbac..."
-kubectl apply -f "${test_dir}/rbac.yaml"
-
 if  [[ ${ENABLE_APISERVER_DEBUG} == "true" ]]
 then
   echo -e "K8S_SHREDDER: Enable debug logging on apiserver"
@@ -45,14 +42,28 @@ then
 curl -s -X PUT -d '5' "$APISERVER"/debug/flags/v --header "Authorization: Bearer $TOKEN" -k
 fi
 
-echo "NODE_LABELS: This test environment will demonstrate node label detection functionality"
-echo "NODE_LABELS: k8s-shredder will detect nodes with specific labels and park them"
-
-echo "KIND: deploying k8s-shredder with node label detection enabled..."
-kubectl apply -f "${test_dir}/k8s-shredder-node-labels.yaml"
+echo "KIND: deploying k8s-shredder using Helm chart..."
+# Use Helm to deploy k8s-shredder with test-specific configuration
+helm install k8s-shredder "${test_dir}/../../charts/k8s-shredder" \
+  --namespace kube-system \
+  --set image.registry=adobe/k8s-shredder \
+  --set image.tag="${K8S_SHREDDER_VERSION}" \
+  --set image.pullPolicy=Never \
+  --set shredder.EvictionLoopInterval=10s \
+  --set shredder.ParkedNodeTTL=30s \
+  --set shredder.RollingRestartThreshold=0.5 \
+  --set shredder.EnableKarpenterDriftDetection=false \
+  --set shredder.EnableNodeLabelDetection=false \
+  --set logLevel=info \
+  --set logFormat=text \
+  --set dryRun=false \
+  --set service.create=true \
+  --set service.type=ClusterIP \
+  --set service.port=8080 \
+  --set service.targetPort=metrics
 
 echo "KIND: deploying prometheus..."
-kubectl apply -f "${test_dir}/prometheus_stuffs_node_labels.yaml"
+kubectl apply -f "${test_dir}/prometheus_stuffs.yaml"
 
 echo "KIND: deploying Argo Rollouts CRD..."
 kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/rollout-crd.yaml
@@ -64,8 +75,6 @@ kubectl apply -f "${test_dir}/test_apps.yaml"
 rollout_uid=$(kubectl -n ns-team-k8s-shredder-test get rollout test-app-argo-rollout -o jsonpath='{.metadata.uid}')
 sed "s/REPLACE_WITH_ROLLOUT_UID/${rollout_uid}/" < "${test_dir}/test_apps.yaml"  | kubectl apply -f -
 
-echo "NODE_LABELS: Node label detection test environment ready!"
-
 echo "K8S_SHREDDER: waiting for k8s-shredder deployment to become ready!"
 retry_count=0
 i=1
@@ -75,7 +84,7 @@ while [[  ${status} == *"False"* || -z ${status} ]]; do
   if [[ ${retry_count} == 600 ]]; then echo "Timeout exceeded!" && exit 1; fi
   # shellcheck disable=SC2059
   printf "\b${sp:i++%${#sp}:1}" && sleep 0.5;
-  status=$(kubectl get pods -n kube-system -l app=k8s-shredder -o json | \
+  status=$(kubectl get pods -n kube-system -l app.kubernetes.io/name=k8s-shredder -o json | \
         jq '.items[].status.conditions[] | select(.type=="Ready")| .status' 2> /dev/null)
   retry_count=$((retry_count+1))
 done
@@ -93,7 +102,7 @@ while [[ $(kubectl get pdb -n ns-team-k8s-shredder-test test-app-argo-rollout \
 done
 
 echo ""
-kubectl logs -l app=k8s-shredder -n kube-system
+kubectl logs -l app.kubernetes.io/name=k8s-shredder -n kube-system
 
 echo "K8S_SHREDDER: waiting for prometheus deployment to become ready!"
 retry_count=0
@@ -113,31 +122,7 @@ kubectl port-forward -n kube-system svc/k8s-shredder --kubeconfig=${KUBECONFIG_F
 It can take few minutes before seeing k8s-shredder metrics..."
 
 echo -e "K8S_SHREDDER: You can access k8s-shredder logs by running
-kubectl logs -n kube-system -l app=k8s-shredder --kubeconfig=${KUBECONFIG_FILE} \n"
+kubectl logs -n kube-system -l app.kubernetes.io/name=k8s-shredder --kubeconfig=${KUBECONFIG_FILE} \n"
 
 echo -e "K8S_SHREDDER: You can access prometheus metrics at http://localhost:1234 after running
-kubectl port-forward -n kube-system svc/prometheus --kubeconfig=${KUBECONFIG_FILE} 1234:9090\n"
-
-echo "NODE_LABELS: Environment setup complete!"
-echo "NODE_LABELS: Configured to detect nodes with these labels:"
-echo "  - test-label (key only)"
-echo "  - maintenance=scheduled (key=value)"
-echo "  - node.test.io/park (key only)"
-echo ""
-
-echo "NODE_LABELS: Now applying test labels to trigger node label detection..."
-
-# Apply test labels to trigger k8s-shredder's node label detection
-WORKER_NODES=($(kubectl get nodes --no-headers -o custom-columns=NAME:.metadata.name | grep -v control-plane))
-WORKER_NODE1=${WORKER_NODES[0]}
-WORKER_NODE2=${WORKER_NODES[1]}
-
-echo "NODE_LABELS: Adding 'test-label=test-value' to node ${WORKER_NODE1}"
-kubectl label node "${WORKER_NODE1}" test-label=test-value
-
-echo "NODE_LABELS: Adding 'maintenance=scheduled' to node ${WORKER_NODE2}"  
-kubectl label node "${WORKER_NODE2}" maintenance=scheduled
-
-echo "NODE_LABELS: Labels applied! k8s-shredder should detect and park these nodes shortly..."
-echo "NODE_LABELS: You can monitor the process with:"
-echo "  kubectl logs -n kube-system -l app=k8s-shredder --kubeconfig=${KUBECONFIG_FILE} -f" 
+kubectl port-forward -n kube-system svc/prometheus --kubeconfig=${KUBECONFIG_FILE} 1234:9090\n" 

--- a/internal/testing/local_env_prep_node_labels_helm.sh
+++ b/internal/testing/local_env_prep_node_labels_helm.sh
@@ -15,7 +15,7 @@ else
   # create a k8s cluster
   echo "KIND: creating cluster ${K8S_CLUSTER_NAME} with version ${KINDNODE_VERSION}..."
   kind create cluster --name "${K8S_CLUSTER_NAME}" --kubeconfig=${KUBECONFIG_FILE} --image "kindest/node:${KINDNODE_VERSION}" \
-      --config "${test_dir}/kind.yaml"
+      --config "${test_dir}/kind-node-labels.yaml"
   export KUBECONFIG=${KUBECONFIG_FILE}
 fi
 
@@ -33,9 +33,6 @@ else
   kubectl create namespace ns-team-k8s-shredder-test
 fi
 
-echo "KIND: setting up k8s-shredder rbac..."
-kubectl apply -f "${test_dir}/rbac.yaml"
-
 if  [[ ${ENABLE_APISERVER_DEBUG} == "true" ]]
 then
   echo -e "K8S_SHREDDER: Enable debug logging on apiserver"
@@ -45,11 +42,34 @@ then
 curl -s -X PUT -d '5' "$APISERVER"/debug/flags/v --header "Authorization: Bearer $TOKEN" -k
 fi
 
-echo "KIND: deploying k8s-shredder..."
-kubectl apply -f "${test_dir}/k8s-shredder.yaml"
+echo "NODE_LABELS: This test environment will demonstrate node label detection functionality"
+echo "NODE_LABELS: k8s-shredder will detect nodes with specific labels and park them"
+
+echo "KIND: deploying k8s-shredder using Helm chart with node label detection enabled..."
+# Use Helm to deploy k8s-shredder with node label detection enabled
+helm install k8s-shredder "${test_dir}/../../charts/k8s-shredder" \
+  --namespace kube-system \
+  --set image.registry=adobe/k8s-shredder \
+  --set image.tag="${K8S_SHREDDER_VERSION}" \
+  --set image.pullPolicy=Never \
+  --set shredder.EvictionLoopInterval=30s \
+  --set shredder.ParkedNodeTTL=2m \
+  --set shredder.RollingRestartThreshold=0.5 \
+  --set shredder.EnableKarpenterDriftDetection=false \
+  --set shredder.EnableNodeLabelDetection=true \
+  --set shredder.NodeLabelsToDetect[0]="test-label" \
+  --set shredder.NodeLabelsToDetect[1]="maintenance=scheduled" \
+  --set shredder.NodeLabelsToDetect[2]="node.test.io/park" \
+  --set logLevel=info \
+  --set logFormat=text \
+  --set dryRun=false \
+  --set service.create=true \
+  --set service.type=ClusterIP \
+  --set service.port=8080 \
+  --set service.targetPort=metrics
 
 echo "KIND: deploying prometheus..."
-kubectl apply -f "${test_dir}/prometheus_stuffs.yaml"
+kubectl apply -f "${test_dir}/prometheus_stuffs_node_labels.yaml"
 
 echo "KIND: deploying Argo Rollouts CRD..."
 kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/rollout-crd.yaml
@@ -61,6 +81,7 @@ kubectl apply -f "${test_dir}/test_apps.yaml"
 rollout_uid=$(kubectl -n ns-team-k8s-shredder-test get rollout test-app-argo-rollout -o jsonpath='{.metadata.uid}')
 sed "s/REPLACE_WITH_ROLLOUT_UID/${rollout_uid}/" < "${test_dir}/test_apps.yaml"  | kubectl apply -f -
 
+echo "NODE_LABELS: Node label detection test environment ready!"
 
 echo "K8S_SHREDDER: waiting for k8s-shredder deployment to become ready!"
 retry_count=0
@@ -71,7 +92,7 @@ while [[  ${status} == *"False"* || -z ${status} ]]; do
   if [[ ${retry_count} == 600 ]]; then echo "Timeout exceeded!" && exit 1; fi
   # shellcheck disable=SC2059
   printf "\b${sp:i++%${#sp}:1}" && sleep 0.5;
-  status=$(kubectl get pods -n kube-system -l app=k8s-shredder -o json | \
+  status=$(kubectl get pods -n kube-system -l app.kubernetes.io/name=k8s-shredder -o json | \
         jq '.items[].status.conditions[] | select(.type=="Ready")| .status' 2> /dev/null)
   retry_count=$((retry_count+1))
 done
@@ -89,7 +110,7 @@ while [[ $(kubectl get pdb -n ns-team-k8s-shredder-test test-app-argo-rollout \
 done
 
 echo ""
-kubectl logs -l app=k8s-shredder -n kube-system
+kubectl logs -l app.kubernetes.io/name=k8s-shredder -n kube-system
 
 echo "K8S_SHREDDER: waiting for prometheus deployment to become ready!"
 retry_count=0
@@ -109,7 +130,31 @@ kubectl port-forward -n kube-system svc/k8s-shredder --kubeconfig=${KUBECONFIG_F
 It can take few minutes before seeing k8s-shredder metrics..."
 
 echo -e "K8S_SHREDDER: You can access k8s-shredder logs by running
-kubectl logs -n kube-system -l app=k8s-shredder --kubeconfig=${KUBECONFIG_FILE} \n"
+kubectl logs -n kube-system -l app.kubernetes.io/name=k8s-shredder --kubeconfig=${KUBECONFIG_FILE} \n"
 
 echo -e "K8S_SHREDDER: You can access prometheus metrics at http://localhost:1234 after running
 kubectl port-forward -n kube-system svc/prometheus --kubeconfig=${KUBECONFIG_FILE} 1234:9090\n"
+
+echo "NODE_LABELS: Environment setup complete!"
+echo "NODE_LABELS: Configured to detect nodes with these labels:"
+echo "  - test-label (key only)"
+echo "  - maintenance=scheduled (key=value)"
+echo "  - node.test.io/park (key only)"
+echo ""
+
+echo "NODE_LABELS: Now applying test labels to trigger node label detection..."
+
+# Apply test labels to trigger k8s-shredder's node label detection
+WORKER_NODES=($(kubectl get nodes --no-headers -o custom-columns=NAME:.metadata.name | grep -v control-plane))
+WORKER_NODE1=${WORKER_NODES[0]}
+WORKER_NODE2=${WORKER_NODES[1]}
+
+echo "NODE_LABELS: Adding 'test-label=test-value' to node ${WORKER_NODE1}"
+kubectl label node "${WORKER_NODE1}" test-label=test-value
+
+echo "NODE_LABELS: Adding 'maintenance=scheduled' to node ${WORKER_NODE2}"  
+kubectl label node "${WORKER_NODE2}" maintenance=scheduled
+
+echo "NODE_LABELS: Labels applied! k8s-shredder should detect and park these nodes shortly..."
+echo "NODE_LABELS: You can monitor the process with:"
+echo "  kubectl logs -n kube-system -l app.kubernetes.io/name=k8s-shredder --kubeconfig=${KUBECONFIG_FILE} -f" 


### PR DESCRIPTION
## Description

This PR rewrites the local-test* make targets to incorporate the use of the k8s-shredder helm chart during execution (rather than using one-off manifests).  It also add a kubernetes service template to the chart.

## Motivation and Context

This approach has the added benefit of testing the helm chart for errors and/or omissions when testing future new features.  For example, while creating this PR it was found that the helm chart didn't actually support creating a service object.  This PR includes that option (disabled by default) for end-user use.

## How Has This Been Tested?

Results were verified by inspecting the local kind clusters and ensuring that the same test workflow was being performed as before.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
