### PR TITLE
Karpenter Disruption Parking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ kubeconfig*
 dist
 /k8s-shredder
 my-k8s-shredder-values.yaml
+/park-node
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -124,15 +124,16 @@ local-test: build ## Test docker image in a kind cluster (with Karpenter drift a
 		echo >&2 "[WARN] I require kind but it's not installed(see https://kind.sigs.k8s.io). Assuming a cluster is already accessible."; \
 	}
 
-local-test-karpenter: build ## Test docker image in a kind cluster with Karpenter and drift detection enabled
+local-test-karpenter: build ## Test docker image in a kind cluster with Karpenter drift and disruption detection enabled
 	@hash kind 2>/dev/null && { \
-		echo "Test docker image in a kind cluster with Karpenter..."; \
+		echo "Test docker image in a kind cluster with Karpenter drift and disruption detection..."; \
 		./internal/testing/local_env_prep_karpenter_helm.sh "${K8S_SHREDDER_VERSION}" "${KINDNODE_VERSION}" "${TEST_CLUSTERNAME_KARPENTER}" "${KUBECONFIG_KARPENTER}" && \
 		./internal/testing/cluster_upgrade_karpenter.sh "${TEST_CLUSTERNAME_KARPENTER}" "${KUBECONFIG_KARPENTER}" || \
 		exit 1; \
 	} || { \
 		echo >&2 "[WARN] I require kind but it's not installed(see https://kind.sigs.k8s.io). Assuming a cluster is already accessible."; \
 	}
+
 
 local-test-node-labels: build ## Test docker image in a kind cluster with node label detection enabled
 	@hash kind 2>/dev/null && { \

--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   - name: sfotony
     email: gosselin@adobe.com
     url: https://adobe.com
-version: 0.2.5
-appVersion: v0.3.5
+version: 0.2.6
+appVersion: v0.3.6

--- a/charts/k8s-shredder/README.md
+++ b/charts/k8s-shredder/README.md
@@ -1,6 +1,6 @@
 # k8s-shredder
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.5](https://img.shields.io/badge/AppVersion-v0.3.5-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.6](https://img.shields.io/badge/AppVersion-v0.3.6-informational?style=flat-square)
 
 a novel way of dealing with kubernetes nodes blocked from draining
 
@@ -64,9 +64,10 @@ a novel way of dealing with kubernetes nodes blocked from draining
 | serviceAccount.annotations | object | `{}` | Additional annotations for the service account (useful for IAM roles, etc.) |
 | serviceAccount.create | bool | `true` | Create a service account for k8s-shredder |
 | serviceAccount.name | string | `"k8s-shredder"` | Name of the service account |
-| shredder | object | `{"AllowEvictionLabel":"shredder.ethos.adobe.net/allow-eviction","ArgoRolloutsAPIVersion":"v1alpha1","EnableKarpenterDriftDetection":false,"EnableNodeLabelDetection":false,"EvictionLoopInterval":"1h","EvictionSafetyCheck":true,"ExpiresOnLabel":"shredder.ethos.adobe.net/parked-node-expires-on","ExtraParkingLabels":{},"MaxParkedNodes":0,"NamespacePrefixSkipInitialEviction":"ns-ethos-","NodeLabelsToDetect":[],"ParkedByLabel":"shredder.ethos.adobe.net/parked-by","ParkedByValue":"k8s-shredder","ParkedNodeTTL":"168h","ParkedNodeTaint":"shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule","RestartedAtAnnotation":"shredder.ethos.adobe.net/restartedAt","RollingRestartThreshold":0.1,"ToBeDeletedTaint":"ToBeDeletedByClusterAutoscaler","UpgradeStatusLabel":"shredder.ethos.adobe.net/upgrade-status"}` | Core k8s-shredder configuration |
+| shredder | object | `{"AllowEvictionLabel":"shredder.ethos.adobe.net/allow-eviction","ArgoRolloutsAPIVersion":"v1alpha1","EnableKarpenterDisruptionDetection":false,"EnableKarpenterDriftDetection":false,"EnableNodeLabelDetection":false,"EvictionLoopInterval":"1h","EvictionSafetyCheck":true,"ExpiresOnLabel":"shredder.ethos.adobe.net/parked-node-expires-on","ExtraParkingLabels":{},"MaxParkedNodes":0,"NamespacePrefixSkipInitialEviction":"ns-ethos-","NodeLabelsToDetect":[],"ParkedByLabel":"shredder.ethos.adobe.net/parked-by","ParkedByValue":"k8s-shredder","ParkedNodeTTL":"168h","ParkedNodeTaint":"shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule","ParkingReasonLabel":"shredder.ethos.adobe.net/parked-reason","RestartedAtAnnotation":"shredder.ethos.adobe.net/restartedAt","RollingRestartThreshold":0.1,"ToBeDeletedTaint":"ToBeDeletedByClusterAutoscaler","UpgradeStatusLabel":"shredder.ethos.adobe.net/upgrade-status"}` | Core k8s-shredder configuration |
 | shredder.AllowEvictionLabel | string | `"shredder.ethos.adobe.net/allow-eviction"` | Label to explicitly allow eviction on specific resources |
 | shredder.ArgoRolloutsAPIVersion | string | `"v1alpha1"` | API version for Argo Rollouts integration |
+| shredder.EnableKarpenterDisruptionDetection | bool | `false` | Enable Karpenter disruption detection for node lifecycle management |
 | shredder.EnableKarpenterDriftDetection | bool | `false` | Enable Karpenter drift detection for node lifecycle management |
 | shredder.EnableNodeLabelDetection | bool | `false` | Enable detection of nodes based on specific labels |
 | shredder.EvictionLoopInterval | string | `"1h"` | How often to run the main eviction loop |
@@ -80,6 +81,7 @@ a novel way of dealing with kubernetes nodes blocked from draining
 | shredder.ParkedByValue | string | `"k8s-shredder"` | Value set in the ParkedByLabel to identify k8s-shredder as the parking agent |
 | shredder.ParkedNodeTTL | string | `"168h"` | How long parked nodes should remain before being eligible for deletion (7 days default) |
 | shredder.ParkedNodeTaint | string | `"shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule"` | Taint applied to parked nodes to prevent new pod scheduling |
+| shredder.ParkingReasonLabel | string | `"shredder.ethos.adobe.net/parked-reason"` | Label used to track why a node or pod was parked |
 | shredder.RestartedAtAnnotation | string | `"shredder.ethos.adobe.net/restartedAt"` | Annotation to track when a workload was last restarted |
 | shredder.RollingRestartThreshold | float | `0.1` | Maximum percentage of nodes that can be restarted simultaneously during rolling restarts |
 | shredder.ToBeDeletedTaint | string | `"ToBeDeletedByClusterAutoscaler"` | Taint indicating nodes scheduled for deletion by cluster autoscaler |

--- a/charts/k8s-shredder/templates/configmap.yaml
+++ b/charts/k8s-shredder/templates/configmap.yaml
@@ -18,6 +18,7 @@ data:
     ToBeDeletedTaint: "{{.Values.shredder.ToBeDeletedTaint}}"
     ArgoRolloutsAPIVersion: "{{.Values.shredder.ArgoRolloutsAPIVersion}}"
     EnableKarpenterDriftDetection: {{.Values.shredder.EnableKarpenterDriftDetection}}
+    EnableKarpenterDisruptionDetection: {{.Values.shredder.EnableKarpenterDisruptionDetection}}
     ParkedByLabel: "{{.Values.shredder.ParkedByLabel}}"
     ParkedByValue: "{{.Values.shredder.ParkedByValue}}"
     ParkedNodeTaint: "{{.Values.shredder.ParkedNodeTaint}}"
@@ -25,4 +26,5 @@ data:
     NodeLabelsToDetect: {{.Values.shredder.NodeLabelsToDetect | toJson}}
     MaxParkedNodes: {{.Values.shredder.MaxParkedNodes}}
     EvictionSafetyCheck: {{.Values.shredder.EvictionSafetyCheck}}
+    ParkingReasonLabel: "{{.Values.shredder.ParkingReasonLabel}}"
     ExtraParkingLabels: {{.Values.shredder.ExtraParkingLabels | toJson}}

--- a/charts/k8s-shredder/values.yaml
+++ b/charts/k8s-shredder/values.yaml
@@ -50,6 +50,8 @@ shredder:
   ArgoRolloutsAPIVersion: v1alpha1
   # -- Enable Karpenter drift detection for node lifecycle management
   EnableKarpenterDriftDetection: false
+  # -- Enable Karpenter disruption detection for node lifecycle management
+  EnableKarpenterDisruptionDetection: false
   # -- Label to track which component parked a node
   ParkedByLabel: shredder.ethos.adobe.net/parked-by
   # -- Value set in the ParkedByLabel to identify k8s-shredder as the parking agent
@@ -64,6 +66,8 @@ shredder:
   MaxParkedNodes: 0
   # -- Controls whether to perform safety checks before force eviction
   EvictionSafetyCheck: true
+  # -- Label used to track why a node or pod was parked
+  ParkingReasonLabel: shredder.ethos.adobe.net/parked-reason
   # -- Additional labels to apply to nodes and pods during parking
   ExtraParkingLabels: {}
     # Example configuration:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,6 +117,7 @@ func discoverConfig() {
 	viper.SetDefault("ToBeDeletedTaint", "ToBeDeletedByClusterAutoscaler")
 	viper.SetDefault("ArgoRolloutsAPIVersion", "v1alpha1")
 	viper.SetDefault("EnableKarpenterDriftDetection", false)
+	viper.SetDefault("EnableKarpenterDisruptionDetection", false)
 	viper.SetDefault("ParkedByLabel", "shredder.ethos.adobe.net/parked-by")
 	viper.SetDefault("ParkedByValue", "k8s-shredder")
 	viper.SetDefault("ParkedNodeTaint", "shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule")
@@ -125,6 +126,7 @@ func discoverConfig() {
 	viper.SetDefault("MaxParkedNodes", 0)
 	viper.SetDefault("ExtraParkingLabels", map[string]string{})
 	viper.SetDefault("EvictionSafetyCheck", true)
+	viper.SetDefault("ParkingReasonLabel", "shredder.ethos.adobe.net/parked-reason")
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -164,6 +166,7 @@ func parseConfig() {
 		"ToBeDeletedTaint":                   cfg.ToBeDeletedTaint,
 		"ArgoRolloutsAPIVersion":             cfg.ArgoRolloutsAPIVersion,
 		"EnableKarpenterDriftDetection":      cfg.EnableKarpenterDriftDetection,
+		"EnableKarpenterDisruptionDetection": cfg.EnableKarpenterDisruptionDetection,
 		"ParkedByLabel":                      cfg.ParkedByLabel,
 		"ParkedByValue":                      cfg.ParkedByValue,
 		"ParkedNodeTaint":                    cfg.ParkedNodeTaint,
@@ -172,6 +175,7 @@ func parseConfig() {
 		"MaxParkedNodes":                     cfg.MaxParkedNodes,
 		"ExtraParkingLabels":                 cfg.ExtraParkingLabels,
 		"EvictionSafetyCheck":                cfg.EvictionSafetyCheck,
+		"ParkingReasonLabel":                 cfg.ParkingReasonLabel,
 	}).Info("Loaded configuration")
 }
 

--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,7 @@ ParkedNodeTaint: shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule  # Ta
 ArgoRolloutsAPIVersion: v1alpha1  # API version from argoproj.io API group to be used while handling Argo Rollouts objects
 # Karpenter integration
 EnableKarpenterDriftDetection: false  # Controls whether to scan for drifted Karpenter NodeClaims and automatically label their nodes
+EnableKarpenterDisruptionDetection: false  # Controls whether to scan for disrupted Karpenter NodeClaims and automatically label their nodes
 # Node label detection
 EnableNodeLabelDetection: false  # Controls whether to scan for nodes with specific labels and automatically park them
 NodeLabelsToDetect: []  # List of node labels to detect. Supports both key-only and key=value formats
@@ -40,3 +41,6 @@ MaxParkedNodes: 0  # Maximum number of nodes that can be parked simultaneously. 
 
 # Safety settings
 EvictionSafetyCheck: true  # Controls whether to perform safety checks before force eviction. If true, nodes will be unparked if pods don't have required parking labels.
+
+# Parking reason tracking
+ParkingReasonLabel: shredder.ethos.adobe.net/parked-reason  # Label used to track why a node or pod was parked

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -86,6 +86,11 @@ k8s-shredder exposes metrics in Prometheus format to help operators monitor the 
 - **Description**: Total number of drifted Karpenter nodes detected
 - **Use Case**: Monitor the volume of Karpenter drift detection activity
 
+### `shredder_karpenter_disrupted_nodes_total`
+- **Type**: Counter
+- **Description**: Total number of disrupted Karpenter nodes detected
+- **Use Case**: Monitor the volume of Karpenter disruption detection activity
+
 ### `shredder_karpenter_nodes_parked_total`
 - **Type**: Counter
 - **Description**: Total number of Karpenter nodes successfully parked

--- a/internal/testing/cluster_upgrade_karpenter.sh
+++ b/internal/testing/cluster_upgrade_karpenter.sh
@@ -8,28 +8,34 @@ test_dir=$(dirname "${BASH_SOURCE[0]}")
 export KUBECONFIG=${KUBECONFIG_FILE}
 
 echo "==============================================================================="
-echo "KARPENTER: Starting Karpenter drift detection test"
+echo "KARPENTER: Starting Karpenter drift and disruption detection test"
 echo "==============================================================================="
 
 echo "KARPENTER: This is a mock test environment to test k8s-shredder's Karpenter integration"
-echo "KARPENTER: We'll create mock drifted NodeClaims to test the k8s-shredder functionality"
+echo "KARPENTER: We'll create mock drifted and disrupted NodeClaims to test the k8s-shredder functionality"
 echo ""
 
-echo "KARPENTER: Creating a test node to associate with mock NodeClaim..."
-# We need at least one node to test labeling functionality
+echo "KARPENTER: Creating test nodes to associate with mock NodeClaims..."
+# We need at least two nodes to test both drift and disruption detection
 node_count=$(kubectl get nodes --no-headers | wc -l)
-if [[ ${node_count} -eq 0 ]]; then
-    echo "ERROR: No nodes available for testing"
+if [[ ${node_count} -lt 2 ]]; then
+    echo "ERROR: At least 2 nodes required for testing (found ${node_count})"
     exit 1
 fi
 
-# Get the first available node for testing
-test_node=$(kubectl get nodes --no-headers -o custom-columns=":metadata.name" | grep -v "control-plane" | head -1)
-if [[ -z "${test_node}" ]]; then
-    echo "ERROR: No worker nodes available for testing"
+# Get worker nodes for testing
+worker_nodes=($(kubectl get nodes --no-headers -o custom-columns=":metadata.name" | grep -v "control-plane"))
+if [[ ${#worker_nodes[@]} -lt 2 ]]; then
+    echo "ERROR: At least 2 worker nodes required for testing (found ${#worker_nodes[@]})"
     exit 1
 fi
-echo "KARPENTER: Using worker node '${test_node}' for testing"
+
+drift_node="${worker_nodes[0]}"
+disruption_node="${worker_nodes[1]}"
+
+echo "KARPENTER: Using worker nodes:"
+echo "  - Drift test node: '${drift_node}'"
+echo "  - Disruption test node: '${disruption_node}'"
 
 echo "KARPENTER: Creating mock drifted NodeClaim..."
 # Create a mock NodeClaim that appears to be drifted
@@ -55,43 +61,84 @@ status:
     status: "True"
     reason: "NodeReady"
     message: "Node is ready"
-  nodeName: "${test_node}"
+  nodeName: "${drift_node}"
   providerID: "kind://docker/kind/test-node"
 EOF
 
 echo "KARPENTER: Mock drifted NodeClaim created!"
+
+echo "KARPENTER: Creating mock disrupted NodeClaim..."
+# Create a mock NodeClaim that appears to be disrupted
+cat <<EOF | kubectl apply -f -
+apiVersion: karpenter.sh/v1
+kind: NodeClaim
+metadata:
+  name: test-nodeclaim-disrupted
+  labels:
+    karpenter.sh/nodepool: "default"
+spec:
+  requirements:
+  - key: kubernetes.io/arch
+    operator: In
+    values: ["amd64"]
+status:
+  conditions:
+  - type: "Disrupting"
+    status: "True"
+    reason: "Consolidation"
+    message: "Node is being disrupted for consolidation"
+  - type: "Ready"
+    status: "True"
+    reason: "NodeReady"
+    message: "Node is ready"
+  nodeName: "${disruption_node}"
+  providerID: "kind://docker/kind/test-node"
+EOF
+
+echo "KARPENTER: Mock disrupted NodeClaim created!"
 
 echo "KARPENTER: Current NodeClaims:"
 kubectl get nodeclaim -o wide
 echo ""
 
 echo "KARPENTER: Setting up test scenario..."
-first_nodeclaim="test-nodeclaim-drifted"
-associated_node="${test_node}"
+drift_nodeclaim="test-nodeclaim-drifted"
+disruption_nodeclaim="test-nodeclaim-disrupted"
 
-echo "KARPENTER: Target NodeClaim for drift test: ${first_nodeclaim}"
-echo "KARPENTER: Associated node: ${associated_node}"
+echo "KARPENTER: Target NodeClaims:"
+echo "  - Drift test: ${drift_nodeclaim} -> ${drift_node}"
+echo "  - Disruption test: ${disruption_nodeclaim} -> ${disruption_node}"
 
 echo "KARPENTER: Current node labels before k8s-shredder processing:"
-kubectl get node ${associated_node} --show-labels
+echo "Drift node (${drift_node}):"
+kubectl get node ${drift_node} --show-labels
+echo ""
+echo "Disruption node (${disruption_node}):"
+kubectl get node ${disruption_node} --show-labels
 echo ""
 
 echo "KARPENTER: Checking for any existing parking labels..."
-parking_status=$(kubectl get node ${associated_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/upgrade-status}' 2>/dev/null || echo "")
-echo "KARPENTER: Current parking status: ${parking_status:-"Not parked"}"
+drift_parking_status=$(kubectl get node ${drift_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/upgrade-status}' 2>/dev/null || echo "")
+disruption_parking_status=$(kubectl get node ${disruption_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/upgrade-status}' 2>/dev/null || echo "")
+echo "KARPENTER: Current parking status:"
+echo "  - Drift node: ${drift_parking_status:-"Not parked"}"
+echo "  - Disruption node: ${disruption_parking_status:-"Not parked"}"
 
 echo ""
 echo "==============================================================================="
-echo "KARPENTER: Waiting for k8s-shredder to detect and park the drifted node..."
+echo "KARPENTER: Waiting for k8s-shredder to detect and park both nodes..."
 echo "==============================================================================="
 
 echo "KARPENTER: Current k8s-shredder logs:"
 kubectl logs -l app=k8s-shredder -n kube-system --tail=20
 echo ""
 
-echo "KARPENTER: Monitoring k8s-shredder activity for next 3 minutes..."
+echo "KARPENTER: Monitoring k8s-shredder activity for next 5 minutes..."
 start_time=$(date +%s)
-end_time=$((start_time + 180))
+end_time=$((start_time + 300))
+
+drift_parked=false
+disruption_parked=false
 
 while [[ $(date +%s) -lt ${end_time} ]]; do
     current_time=$(date +%s)
@@ -99,67 +146,138 @@ while [[ $(date +%s) -lt ${end_time} ]]; do
     
     echo "KARPENTER: Checking node parking status... (${remaining}s remaining)"
     
-    # Check if node is parked
-    parking_status=$(kubectl get node ${associated_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/upgrade-status}' 2>/dev/null || echo "")
-    parked_by=$(kubectl get node ${associated_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/parked-by}' 2>/dev/null || echo "")
-    expires_on=$(kubectl get node ${associated_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/parked-node-expires-on}' 2>/dev/null || echo "")
+    # Check if drift node is parked
+    if [[ "${drift_parked}" == "false" ]]; then
+        drift_parking_status=$(kubectl get node ${drift_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/upgrade-status}' 2>/dev/null || echo "")
+        if [[ "${drift_parking_status}" == "parked" ]]; then
+            drift_parked=true
+            drift_parked_by=$(kubectl get node ${drift_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/parked-by}' 2>/dev/null || echo "")
+            drift_expires_on=$(kubectl get node ${drift_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/parked-node-expires-on}' 2>/dev/null || echo "")
+            drift_parking_reason=$(kubectl get node ${drift_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/parked-reason}' 2>/dev/null || echo "")
+            echo "KARPENTER: ✅ Drift node ${drift_node} has been parked!"
+            echo "  - Status: ${drift_parking_status}"
+            echo "  - Parked by: ${drift_parked_by}"
+            echo "  - Expires on: ${drift_expires_on}"
+            echo "  - Parking reason: ${drift_parking_reason}"
+        fi
+    fi
     
-    if [[ "${parking_status}" == "parked" ]]; then
+    # Check if disruption node is parked
+    if [[ "${disruption_parked}" == "false" ]]; then
+        disruption_parking_status=$(kubectl get node ${disruption_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/upgrade-status}' 2>/dev/null || echo "")
+        if [[ "${disruption_parking_status}" == "parked" ]]; then
+            disruption_parked=true
+            disruption_parked_by=$(kubectl get node ${disruption_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/parked-by}' 2>/dev/null || echo "")
+            disruption_expires_on=$(kubectl get node ${disruption_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/parked-node-expires-on}' 2>/dev/null || echo "")
+            disruption_parking_reason=$(kubectl get node ${disruption_node} -o jsonpath='{.metadata.labels.shredder\.ethos\.adobe\.net/parked-reason}' 2>/dev/null || echo "")
+            echo "KARPENTER: ✅ Disruption node ${disruption_node} has been parked!"
+            echo "  - Status: ${disruption_parking_status}"
+            echo "  - Parked by: ${disruption_parked_by}"
+            echo "  - Expires on: ${disruption_expires_on}"
+            echo "  - Parking reason: ${disruption_parking_reason}"
+        fi
+    fi
+    
+    # Check if both nodes are parked
+    if [[ "${drift_parked}" == "true" && "${disruption_parked}" == "true" ]]; then
         echo ""
         echo "==============================================================================="
-        echo "KARPENTER: SUCCESS! Node ${associated_node} has been parked by k8s-shredder!"
+        echo "KARPENTER: SUCCESS! Both nodes have been parked by k8s-shredder!"
         echo "==============================================================================="
-        echo "KARPENTER: Parking details:"
-        echo "  - Status: ${parking_status}"
-        echo "  - Parked by: ${parked_by}"
-        echo "  - Expires on: ${expires_on}"
+        echo "KARPENTER: Final parking details:"
+        echo ""
+        echo "Drift node (${drift_node}):"
+        echo "  - Status: ${drift_parking_status}"
+        echo "  - Parked by: ${drift_parked_by}"
+        echo "  - Expires on: ${drift_expires_on}"
+        echo "  - Parking reason: ${drift_parking_reason}"
+        echo ""
+        echo "Disruption node (${disruption_node}):"
+        echo "  - Status: ${disruption_parking_status}"
+        echo "  - Parked by: ${disruption_parked_by}"
+        echo "  - Expires on: ${disruption_expires_on}"
+        echo "  - Parking reason: ${disruption_parking_reason}"
         echo ""
         
-        echo "KARPENTER: Checking if node is also cordoned and tainted..."
-        node_unschedulable=$(kubectl get node ${associated_node} -o jsonpath='{.spec.unschedulable}' 2>/dev/null || echo "")
-        echo "  - Unschedulable (cordoned): ${node_unschedulable}"
-        
+        echo "KARPENTER: Checking if nodes are also cordoned and tainted..."
+        echo "Drift node (${drift_node}):"
+        drift_unschedulable=$(kubectl get node ${drift_node} -o jsonpath='{.spec.unschedulable}' 2>/dev/null || echo "")
+        echo "  - Unschedulable (cordoned): ${drift_unschedulable}"
         echo "  - Taints:"
-        kubectl get node ${associated_node} -o jsonpath='{.spec.taints}' | jq -r '.[] | "    \(.key)=\(.value):\(.effect)"' 2>/dev/null || echo "    No taints found"
-        
+        kubectl get node ${drift_node} -o jsonpath='{.spec.taints}' | jq -r '.[] | "    \(.key)=\(.value):\(.effect)"' 2>/dev/null || echo "    No taints found"
         echo ""
-        echo "KARPENTER: Checking pods on the node..."
-        kubectl get pods --all-namespaces --field-selector spec.nodeName=${associated_node} -o wide
         
+        echo "Disruption node (${disruption_node}):"
+        disruption_unschedulable=$(kubectl get node ${disruption_node} -o jsonpath='{.spec.unschedulable}' 2>/dev/null || echo "")
+        echo "  - Unschedulable (cordoned): ${disruption_unschedulable}"
+        echo "  - Taints:"
+        kubectl get node ${disruption_node} -o jsonpath='{.spec.taints}' | jq -r '.[] | "    \(.key)=\(.value):\(.effect)"' 2>/dev/null || echo "    No taints found"
         echo ""
+        
+        echo "KARPENTER: Checking pods on the nodes..."
+        echo "Pods on drift node (${drift_node}):"
+        kubectl get pods --all-namespaces --field-selector spec.nodeName=${drift_node} -o wide
+        echo ""
+        echo "Pods on disruption node (${disruption_node}):"
+        kubectl get pods --all-namespaces --field-selector spec.nodeName=${disruption_node} -o wide
+        echo ""
+        
         echo "KARPENTER: Final k8s-shredder logs:"
         kubectl logs -l app=k8s-shredder -n kube-system --tail=30
-        
         echo ""
+        
         echo "==============================================================================="
         echo "KARPENTER: Test completed successfully!"
         echo "==============================================================================="
         echo "KARPENTER: Summary:"
         echo "  1. ✅ Mock drifted NodeClaim was created"
-        echo "  2. ✅ NodeClaim was marked as drifted"  
-        echo "  3. ✅ k8s-shredder detected and parked the node"
-        echo "  4. ✅ Node was labeled, cordoned, and tainted"
-        echo "  5. ✅ Pods on the node were also labeled"
+        echo "  2. ✅ Mock disrupted NodeClaim was created"
+        echo "  3. ✅ Both NodeClaims were marked with appropriate conditions"
+        echo "  4. ✅ k8s-shredder detected and parked both nodes"
+        echo "  5. ✅ Nodes were labeled, cordoned, and tainted"
+        echo "  6. ✅ Pods on the nodes were also labeled"
+        echo "  7. ✅ Parking reason labels were applied correctly"
+        echo ""
+        echo "KARPENTER: Parking reason validation:"
+        if [[ "${drift_parking_reason}" == "karpenter-drift" ]]; then
+            echo "  ✅ Drift node has correct parking reason: ${drift_parking_reason}"
+        else
+            echo "  ❌ Drift node has incorrect parking reason: ${drift_parking_reason} (expected: karpenter-drift)"
+        fi
+        
+        if [[ "${disruption_parking_reason}" == "karpenter-disruption" ]]; then
+            echo "  ✅ Disruption node has correct parking reason: ${disruption_parking_reason}"
+        else
+            echo "  ❌ Disruption node has incorrect parking reason: ${disruption_parking_reason} (expected: karpenter-disruption)"
+        fi
         echo ""
         exit 0
     fi
     
-    echo "KARPENTER: Node parking status: ${parking_status:-"Not parked yet"}"
+    echo "KARPENTER: Current status:"
+    echo "  - Drift node (${drift_node}): ${drift_parking_status:-"Not parked yet"}"
+    echo "  - Disruption node (${disruption_node}): ${disruption_parking_status:-"Not parked yet"}"
     sleep 10
 done
 
 echo ""
 echo "==============================================================================="
-echo "KARPENTER: Test completed but node was not parked within timeout"
+echo "KARPENTER: Test completed but not all nodes were parked within timeout"
 echo "==============================================================================="
 echo "KARPENTER: Final status check:"
 
 echo "KARPENTER: Node labels:"
-kubectl get node ${associated_node} --show-labels
+echo "Drift node (${drift_node}):"
+kubectl get node ${drift_node} --show-labels
+echo ""
+echo "Disruption node (${disruption_node}):"
+kubectl get node ${disruption_node} --show-labels
 echo ""
 
 echo "KARPENTER: Final NodeClaim status:"
-kubectl get nodeclaim ${first_nodeclaim} -o yaml
+kubectl get nodeclaim ${drift_nodeclaim} -o yaml
+echo ""
+kubectl get nodeclaim ${disruption_nodeclaim} -o yaml
 echo ""
 
 echo "KARPENTER: Final k8s-shredder logs:"
@@ -176,7 +294,7 @@ echo ""
 
 echo "KARPENTER: k8s-shredder may need more time or there might be an issue."
 echo "KARPENTER: Check the logs above for any errors or continue monitoring manually."
-echo "KARPENTER: This could be expected behavior if Karpenter drift detection is disabled or"
+echo "KARPENTER: This could be expected behavior if Karpenter detection is disabled or"
 echo "KARPENTER: if k8s-shredder hasn't run its eviction loop yet."
 
 exit 1 

--- a/internal/testing/local_env_prep_karpenter_helm.sh
+++ b/internal/testing/local_env_prep_karpenter_helm.sh
@@ -127,6 +127,7 @@ helm install k8s-shredder "${test_dir}/../../charts/k8s-shredder" \
   --set shredder.ParkedNodeTTL=2m \
   --set shredder.RollingRestartThreshold=0.5 \
   --set shredder.EnableKarpenterDriftDetection=true \
+  --set shredder.EnableKarpenterDisruptionDetection=true \
   --set shredder.EnableNodeLabelDetection=false \
   --set logLevel=debug \
   --set logFormat=text \

--- a/internal/testing/park_node.go
+++ b/internal/testing/park_node.go
@@ -41,6 +41,7 @@ func ParkNodeForTesting(nodeName string, kubeconfigPath string) error {
 		ParkedNodeTaint:     "shredder.ethos.adobe.net/upgrade-status=parked:NoSchedule",
 		EvictionSafetyCheck: true, // Keep safety check enabled
 		ExtraParkingLabels:  map[string]string{},
+		ParkingReasonLabel:  "shredder.ethos.adobe.net/parked-reason",
 	}
 
 	// Create logger

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	ArgoRolloutsAPIVersion string
 	// EnableKarpenterDriftDetection controls whether to scan for drifted Karpenter NodeClaims and automatically label their nodes
 	EnableKarpenterDriftDetection bool
+	// EnableKarpenterDisruptionDetection controls whether to scan for disrupted Karpenter NodeClaims and automatically label their nodes
+	EnableKarpenterDisruptionDetection bool
 	// ParkedByLabel is used for identifying which component parked the node
 	ParkedByLabel string
 	// ParkedByValue is the value to set for the ParkedByLabel
@@ -53,4 +55,6 @@ type Config struct {
 	ExtraParkingLabels map[string]string
 	// EvictionSafetyCheck controls whether to perform safety checks before force eviction. If true, nodes will be unparked if pods don't have required parking labels.
 	EvictionSafetyCheck bool
+	// ParkingReasonLabel is the label used to track why a node or pod was parked
+	ParkingReasonLabel string
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -112,6 +112,14 @@ var (
 		},
 	)
 
+	// ShredderKarpenterDisruptedNodesTotal = Total number of disrupted Karpenter nodes detected
+	ShredderKarpenterDisruptedNodesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "shredder_karpenter_disrupted_nodes_total",
+			Help: "Total number of disrupted Karpenter nodes detected",
+		},
+	)
+
 	// ShredderKarpenterNodesParkedTotal = Total number of Karpenter nodes successfully parked
 	ShredderKarpenterNodesParkedTotal = prometheus.NewCounter(
 		prometheus.CounterOpts{

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -45,6 +45,7 @@ func registerMetrics() error {
 	prometheus.MustRegister(ShredderNodeForceToEvictTime)
 	prometheus.MustRegister(ShredderPodForceToEvictTime)
 	prometheus.MustRegister(ShredderKarpenterDriftedNodesTotal)
+	prometheus.MustRegister(ShredderKarpenterDisruptedNodesTotal)
 	prometheus.MustRegister(ShredderKarpenterNodesParkedTotal)
 	prometheus.MustRegister(ShredderKarpenterNodesParkingFailedTotal)
 	prometheus.MustRegister(ShredderKarpenterProcessingDurationSeconds)

--- a/pkg/utils/parking.go
+++ b/pkg/utils/parking.go
@@ -42,6 +42,8 @@ type ParkingLabels struct {
 	ExpiresOnValue     string
 	ParkedByLabel      string
 	ParkedByValue      string
+	ParkingReasonLabel string
+	ParkingReasonValue string
 	ExtraLabels        map[string]string // Extra labels to apply to nodes and pods
 }
 
@@ -236,6 +238,8 @@ func labelNode(ctx context.Context, k8sClient kubernetes.Interface, nodeName str
 		"expiresOnValue":     labels.ExpiresOnValue,
 		"parkedByLabel":      labels.ParkedByLabel,
 		"parkedByValue":      labels.ParkedByValue,
+		"parkingReasonLabel": labels.ParkingReasonLabel,
+		"parkingReasonValue": labels.ParkingReasonValue,
 		"extraLabels":        labels.ExtraLabels,
 		"dryRun":             dryRun,
 	})
@@ -267,6 +271,7 @@ func labelNode(ctx context.Context, k8sClient kubernetes.Interface, nodeName str
 	node.Labels[labels.UpgradeStatusLabel] = labels.UpgradeStatusValue
 	node.Labels[labels.ExpiresOnLabel] = labels.ExpiresOnValue
 	node.Labels[labels.ParkedByLabel] = labels.ParkedByValue
+	node.Labels[labels.ParkingReasonLabel] = labels.ParkingReasonValue
 	// Apply extra labels
 	for k, v := range labels.ExtraLabels {
 		node.Labels[k] = v
@@ -299,6 +304,8 @@ func labelPod(ctx context.Context, k8sClient kubernetes.Interface, pod v1.Pod, l
 		"expiresOnValue":     labels.ExpiresOnValue,
 		"parkedByLabel":      labels.ParkedByLabel,
 		"parkedByValue":      labels.ParkedByValue,
+		"parkingReasonLabel": labels.ParkingReasonLabel,
+		"parkingReasonValue": labels.ParkingReasonValue,
 		"extraLabels":        labels.ExtraLabels,
 		"dryRun":             dryRun,
 	})
@@ -330,6 +337,7 @@ func labelPod(ctx context.Context, k8sClient kubernetes.Interface, pod v1.Pod, l
 	currentPod.Labels[labels.UpgradeStatusLabel] = labels.UpgradeStatusValue
 	currentPod.Labels[labels.ExpiresOnLabel] = labels.ExpiresOnValue
 	currentPod.Labels[labels.ParkedByLabel] = labels.ParkedByValue
+	currentPod.Labels[labels.ParkingReasonLabel] = labels.ParkingReasonValue
 	// Apply extra labels
 	for k, v := range labels.ExtraLabels {
 		currentPod.Labels[k] = v
@@ -381,6 +389,8 @@ func ParkNodes(ctx context.Context, k8sClient kubernetes.Interface, nodes []Node
 		ExpiresOnValue:     expirationUnixTime,
 		ParkedByLabel:      cfg.ParkedByLabel,
 		ParkedByValue:      cfg.ParkedByValue,
+		ParkingReasonLabel: cfg.ParkingReasonLabel,
+		ParkingReasonValue: source,
 		ExtraLabels:        cfg.ExtraParkingLabels,
 	}
 
@@ -623,6 +633,9 @@ func UnparkPod(ctx context.Context, k8sClient kubernetes.Interface, pod v1.Pod, 
 		// Remove ParkedByLabel
 		delete(podCopy.Labels, cfg.ParkedByLabel)
 
+		// Remove ParkingReasonLabel
+		delete(podCopy.Labels, cfg.ParkingReasonLabel)
+
 		// Remove ExtraParkingLabels
 		for key := range cfg.ExtraParkingLabels {
 			delete(podCopy.Labels, key)
@@ -668,6 +681,9 @@ func unparkNodeObject(ctx context.Context, k8sClient kubernetes.Interface, node 
 
 		// Remove ParkedByLabel
 		delete(nodeCopy.Labels, cfg.ParkedByLabel)
+
+		// Remove ParkingReasonLabel
+		delete(nodeCopy.Labels, cfg.ParkingReasonLabel)
 
 		// Remove ExtraParkingLabels
 		for key := range cfg.ExtraParkingLabels {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the ability to park nodes that are in a karpenter-disrupted state.  Also adds a new node and pod label during parking that notes the reason for parking.

## Motivation and Context

This is a useful feature to ensure that nodes in heavily disrupted clusters that are bound by strict node disruption budgets have a reasonable timeline for pod eviction.  This was requested by an end user organization.

## How Has This Been Tested?

Testing has been built into the e2e rubric.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
