### PR TITLE
fix(ci): disable govet inline analyzer broken by Go 1.25 + golangci-lint v9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           # version: v1.46
-          args: -v --timeout 5m --no-config ./...
+          args: -v --timeout 5m ./...
       - name: Install k8s Kind Cluster
         uses: helm/kind-action@v1.13.0
         with:
@@ -50,7 +50,7 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           # version: v1.46
-          args: -v --timeout 5m --no-config ./...
+          args: -v --timeout 5m ./...
       - name: Install k8s Kind Cluster
         uses: helm/kind-action@v1.13.0
         with:
@@ -79,7 +79,7 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           # version: v1.46
-          args: -v --timeout 5m --no-config ./...
+          args: -v --timeout 5m ./...
       - name: Install k8s Kind Cluster
         uses: helm/kind-action@v1.13.0
         with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,4 @@
+linters-settings:
+  govet:
+    disable:
+      - inline

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,6 @@
-linters-settings:
-  govet:
-    disable:
-      - inline
+version: "2"
+linters:
+  settings:
+    govet:
+      disable:
+        - inline


### PR DESCRIPTION
## Summary

- Go 1.25 introduced a new `govet` analysis pass (`inline`) that does not yet support type parameter inference
- `golangci-lint-action@v9` (unpinned, uses latest) now runs this analyzer by default
- Every call to `slices.Contains` is flagged: `cannot inline: type parameter inference is not yet supported`
- This breaks all PRs CI: `ci`, `ci-karpenter`, `ci-node-labels`

## Changes

- Add `.golangci.yaml` disabling the `govet` `inline` sub-analyzer
- Remove `--no-config` from all three CI jobs so golangci-lint picks up the config

## Test plan

- [x] CI passes on this PR
- [x] Renovate PRs that rebase on main will unblock automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)