### PR TITLE
ci: declare contents:read on chart-testing workflow

### DIFF
--- a/.github/workflows/ci-chart.yaml
+++ b/.github/workflows/ci-chart.yaml
@@ -1,6 +1,9 @@
 ---
 name: Lint and Test Helm Chart
 on: pull_request
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins `.github/workflows/ci-chart.yaml` to `permissions: contents: read` at the workflow level. The chart-testing pipeline only checks out source, sets up `helm`, `python`, and `kind`, then runs `ct lint-and-install`. None of those steps need write access through `GITHUB_TOKEN`.

The reason to bother with an explicit declaration even when the org default may already be read is the runtime supply-chain threat: CVE-2025-30066 (`tj-actions/changed-files`, March 2025) demonstrated a tampered third-party action exfiltrating `GITHUB_TOKEN` from workflow logs, and the leaked token carried whatever scope was issued. Declaring `contents: read` per workflow caps that runtime authority regardless of the org default, gives drift protection if a future org-level change widens it, and registers on OpenSSF Scorecard's Token-Permissions check (which only credits explicit per-workflow blocks).

Validated with `yaml.safe_load` before push.
