### PR TITLE
Implemented the grafana dashboard for ks-shredder (#4)

### DIFF
--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   - name: sfotony
     email: gosselin@adobe.com
     url: https://adobe.com
-version: 0.2.8
+version: 0.2.9
 appVersion: v0.3.8

--- a/charts/k8s-shredder/README.md
+++ b/charts/k8s-shredder/README.md
@@ -23,6 +23,18 @@ a novel way of dealing with kubernetes nodes blocked from draining
 | dryRun | bool | `false` | Enable dry-run mode - when true, k8s-shredder will log actions but not execute them |
 | environmentVars | list | `[]` | Additional environment variables to set in the container |
 | fullnameOverride | string | `""` | Override the full name used for resources |
+| grafanaDashboard | object | `{"enabled":false,"folder":"","labelKey":"grafana_dashboard","labelValue":"1","labels":{}}` | Grafana dashboard configuration |
+| grafanaDashboard.enabled | bool | `false` | Create a ConfigMap containing a sample Grafana dashboard for k8s-shredder metrics. Auto-discovered by Grafana's dashboard sidecar (e.g. kube-prometheus-stack's grafana.sidecar.dashboards), if one is watching for it. Has no effect otherwise. |
+| grafanaDashboard.folder | string | `""` | Optional Grafana folder to place the dashboard under (requires sidecar folder annotation support, e.g. kube-prometheus-stack's grafana.sidecar.dashboards.folderAnnotation) |
+| grafanaDashboard.labelKey | string | `"grafana_dashboard"` | Label key applied to the ConfigMap for the Grafana sidecar to discover it (must match your Grafana sidecar's configured label key, e.g. `grafana_dashboard` for kube-prometheus-stack defaults) |
+| grafanaDashboard.labelValue | string | `"1"` | Label value applied to the ConfigMap for the Grafana sidecar to discover it |
+| grafanaDashboard.labels | object | `{}` | Additional labels for the ConfigMap |
+| grafanaDatasource | object | `{"enabled":false,"isDefault":false,"labelKey":"grafana_datasource","labelValue":"1","url":""}` | Grafana datasource configuration. The dashboard's panels (see grafanaDashboard) all reference a |
+| grafanaDatasource.enabled | bool | `false` | Create a ConfigMap provisioning a Prometheus datasource in Grafana (uid: prometheus, matching the dashboard's panel references). Auto-discovered by Grafana's datasource sidecar (e.g. kube-prometheus-stack's grafana.sidecar.datasources), if one is watching for it. Has no effect otherwise. |
+| grafanaDatasource.isDefault | bool | `false` | Whether this datasource should be set as Grafana's default |
+| grafanaDatasource.labelKey | string | `"grafana_datasource"` | Label key applied to the ConfigMap for the Grafana sidecar to discover it (must match your Grafana sidecar's configured label key, e.g. `grafana_datasource` for kube-prometheus-stack defaults) |
+| grafanaDatasource.labelValue | string | `"1"` | Label value applied to the ConfigMap for the Grafana sidecar to discover it |
+| grafanaDatasource.url | string | `""` | URL of the Prometheus instance scraping k8s-shredder (required if enabled), e.g. http://prometheus-operated.monitoring.svc:9090 |
 | image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io/adobe/k8s-shredder","tag":"latest"}` | Container image configuration |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy - IfNotPresent, Always, or Never |
 | image.registry | string | `"ghcr.io/adobe/k8s-shredder"` | Container registry where the k8s-shredder image is hosted |

--- a/charts/k8s-shredder/dashboards/k8s-shredder-dashboard.json
+++ b/charts/k8s-shredder/dashboards/k8s-shredder-dashboard.json
@@ -1,0 +1,481 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "ops" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 1 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_loops_total[5m])",
+          "legendFormat": "loops/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Eviction Loops Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "ops" },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "errors/s" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 1 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_errors_total[5m])",
+          "legendFormat": "errors/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_loops_duration_seconds{quantile=\"0.5\"}",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_loops_duration_seconds{quantile=\"0.9\"}",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_loops_duration_seconds{quantile=\"0.99\"}",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Loop Duration (quantiles)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "ops" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "id": 4,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_processed_nodes_total[5m])",
+          "legendFormat": "nodes/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Processed Nodes Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "ops" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_processed_pods_total[5m])",
+          "legendFormat": "pods/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Processed Pods Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "id": 300,
+      "panels": [],
+      "title": "Node & Pod Processing",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "points", "fillOpacity": 0, "pointSize": 5 }, "unit": "dateTimeAsIso" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "id": 8,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_node_force_to_evict_time * 1000",
+          "legendFormat": "{{node_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Node Forced Eviction Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "points", "fillOpacity": 0, "pointSize": 5 }, "unit": "dateTimeAsIso" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "id": 9,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_pod_force_to_evict_time * 1000",
+          "legendFormat": "{{namespace}}/{{pod_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Forced Eviction Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto" } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 26 },
+      "id": 10,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_pod_errors_total",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Errors (current)",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 400,
+      "panels": [],
+      "title": "Karpenter Drift Detection",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "ops" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "id": 11,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_karpenter_drifted_nodes_total[5m])",
+          "legendFormat": "drifted/s",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_karpenter_disrupted_nodes_total[5m])",
+          "legendFormat": "disrupted/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Drifted / Disrupted Nodes Detected",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "ops" },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "parking failed/s" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "id": 12,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_karpenter_nodes_parked_total[5m])",
+          "legendFormat": "parked/s",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_karpenter_nodes_parking_failed_total[5m])",
+          "legendFormat": "parking failed/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Karpenter Nodes Parked vs Failed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 43 },
+      "id": 13,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_karpenter_processing_duration_seconds{quantile=\"0.5\"}",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_karpenter_processing_duration_seconds{quantile=\"0.9\"}",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_karpenter_processing_duration_seconds{quantile=\"0.99\"}",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Karpenter Processing Duration (quantiles)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 51 },
+      "id": 500,
+      "panels": [],
+      "title": "Node Label Detection",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 52 },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_node_label_matching_nodes_total",
+          "legendFormat": "matching nodes",
+          "refId": "A"
+        }
+      ],
+      "title": "Current Matching Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "ops" },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "parking failed/s" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 18, "x": 6, "y": 52 },
+      "id": 15,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_node_label_nodes_parked_total[5m])",
+          "legendFormat": "parked/s",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_node_label_nodes_parking_failed_total[5m])",
+          "legendFormat": "parking failed/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Node Label Nodes Parked vs Failed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 60 },
+      "id": 16,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_node_label_processing_duration_seconds{quantile=\"0.5\"}",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_node_label_processing_duration_seconds{quantile=\"0.9\"}",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_node_label_processing_duration_seconds{quantile=\"0.99\"}",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Node Label Processing Duration (quantiles)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 68 },
+      "id": 600,
+      "panels": [],
+      "title": "Shared Parking Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1 },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 69 },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(shredder_nodes_parked_total[5m]) / clamp_min(rate(shredder_nodes_parked_total[5m]) + rate(shredder_nodes_parking_failed_total[5m]), 1e-9)",
+          "legendFormat": "success rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Overall Node Parking Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10 }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 69 },
+      "id": 18,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_processing_duration_seconds{quantile=\"0.5\"}",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_processing_duration_seconds{quantile=\"0.9\"}",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "shredder_processing_duration_seconds{quantile=\"0.99\"}",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Overall Processing Duration (quantiles)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["k8s-shredder", "kubernetes", "node-parking"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "k8s-shredder",
+  "uid": "k8s-shredder",
+  "version": 1,
+  "weekStart": ""
+}

--- a/charts/k8s-shredder/templates/grafana-dashboard.yaml
+++ b/charts/k8s-shredder/templates/grafana-dashboard.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.grafanaDashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "k8s-shredder.fullname" . }}-grafana-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "k8s-shredder.labels" . | indent 4 }}
+    {{ .Values.grafanaDashboard.labelKey }}: {{ .Values.grafanaDashboard.labelValue | quote }}
+  {{- with .Values.grafanaDashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.grafanaDashboard.folder }}
+  annotations:
+    grafana_folder: {{ .Values.grafanaDashboard.folder | quote }}
+  {{- end }}
+data:
+  k8s-shredder-dashboard.json: |-
+{{ .Files.Get "dashboards/k8s-shredder-dashboard.json" | indent 4 }}
+{{- end }}

--- a/charts/k8s-shredder/templates/grafana-datasource.yaml
+++ b/charts/k8s-shredder/templates/grafana-datasource.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.grafanaDatasource.enabled }}
+{{- if not .Values.grafanaDatasource.url }}
+{{- fail "grafanaDatasource.url is required when grafanaDatasource.enabled is true" }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "k8s-shredder.fullname" . }}-grafana-datasource
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "k8s-shredder.labels" . | indent 4 }}
+    {{ .Values.grafanaDatasource.labelKey }}: {{ .Values.grafanaDatasource.labelValue | quote }}
+data:
+  k8s-shredder-datasource.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        uid: prometheus
+        access: proxy
+        url: {{ .Values.grafanaDatasource.url | quote }}
+        isDefault: {{ .Values.grafanaDatasource.isDefault }}
+{{- end }}

--- a/charts/k8s-shredder/values.yaml
+++ b/charts/k8s-shredder/values.yaml
@@ -159,6 +159,32 @@ podMonitor:
   honorLabels: true
   # -- Metric relabeling configuration
   relabelings: []
+# -- Grafana dashboard configuration
+grafanaDashboard:
+  # -- Create a ConfigMap containing a sample Grafana dashboard for k8s-shredder metrics. Auto-discovered by Grafana's dashboard sidecar (e.g. kube-prometheus-stack's grafana.sidecar.dashboards), if one is watching for it. Has no effect otherwise.
+  enabled: false
+  # -- Label key applied to the ConfigMap for the Grafana sidecar to discover it (must match your Grafana sidecar's configured label key, e.g. `grafana_dashboard` for kube-prometheus-stack defaults)
+  labelKey: grafana_dashboard
+  # -- Label value applied to the ConfigMap for the Grafana sidecar to discover it
+  labelValue: '1'
+  # -- Optional Grafana folder to place the dashboard under (requires sidecar folder annotation support, e.g. kube-prometheus-stack's grafana.sidecar.dashboards.folderAnnotation)
+  folder: ''
+  # -- Additional labels for the ConfigMap
+  labels: {}
+# -- Grafana datasource configuration. The dashboard's panels (see grafanaDashboard) all reference a
+# -- datasource with uid "prometheus" - enabling this provisions one pointing at your Prometheus, so the
+# -- dashboard actually has something to query instead of showing "Datasource prometheus not found".
+grafanaDatasource:
+  # -- Create a ConfigMap provisioning a Prometheus datasource in Grafana (uid: prometheus, matching the dashboard's panel references). Auto-discovered by Grafana's datasource sidecar (e.g. kube-prometheus-stack's grafana.sidecar.datasources), if one is watching for it. Has no effect otherwise.
+  enabled: false
+  # -- URL of the Prometheus instance scraping k8s-shredder (required if enabled), e.g. http://prometheus-operated.monitoring.svc:9090
+  url: ''
+  # -- Label key applied to the ConfigMap for the Grafana sidecar to discover it (must match your Grafana sidecar's configured label key, e.g. `grafana_datasource` for kube-prometheus-stack defaults)
+  labelKey: grafana_datasource
+  # -- Label value applied to the ConfigMap for the Grafana sidecar to discover it
+  labelValue: '1'
+  # -- Whether this datasource should be set as Grafana's default
+  isDefault: false
 # -- Priority class for pod scheduling - system-cluster-critical ensures high priority
 priorityClassName: system-cluster-critical
 # -- Topology spread constraints to control pod distribution across failure domains

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -403,7 +403,7 @@ func (h *Handler) evictPod(pod v1.Pod, deleteOptions *metav1.DeleteOptions) erro
 	})
 
 	if err != nil {
-		metrics.ShredderPodErrorsTotal.WithLabelValues(pod.Name, pod.Namespace, err.Error(), "evict")
+		metrics.ShredderPodErrorsTotal.WithLabelValues(pod.Name, pod.Namespace, err.Error(), "evict").Set(1)
 		return err
 	}
 
@@ -418,7 +418,7 @@ func (h *Handler) deletePod(pod v1.Pod, deleteOptions *metav1.DeleteOptions) err
 	err := coreClient.Pods(pod.Namespace).Delete(h.appContext.Context, pod.Name, *deleteOptions)
 
 	if err != nil {
-		metrics.ShredderPodErrorsTotal.WithLabelValues(pod.Name, pod.Namespace, err.Error(), "delete")
+		metrics.ShredderPodErrorsTotal.WithLabelValues(pod.Name, pod.Namespace, err.Error(), "delete").Set(1)
 		return err
 	}
 


### PR DESCRIPTION
## Description

Adds optional Helm chart support for provisioning a Grafana dashboard and a matching Prometheus datasource for k8s-shredder, and fixes a metrics bug that was silently dropping pod error data.
 
- New `charts/k8s-shredder/dashboards/k8s-shredder-dashboard.json` — a ready-made Grafana dashboard covering eviction loops, error rates, node/pod forced-eviction timing, pod errors, and the Karpenter/node-label detection metrics.
- New `charts/k8s-shredder/templates/grafana-dashboard.yaml` — renders the dashboard JSON into a ConfigMap, labeled for auto-discovery by Grafana's dashboard sidecar (e.g. kube-prometheus-stack's `grafana.sidecar.dashboards`). Disabled by default (`grafanaDashboard.enabled: false`).
- New `charts/k8s-shredder/templates/grafana-datasource.yaml` — optionally provisions a Prometheus datasource (`uid: prometheus`, matching the dashboard's panel references) via the same sidecar mechanism. Disabled by default (`grafanaDatasource.enabled: false`).
- `charts/k8s-shredder/values.yaml` / `README.md` — new `grafanaDashboard.*` and `grafanaDatasource.*` values documented and added to the chart's values table.
- `pkg/handler/handler.go` — fixed `ShredderPodErrorsTotal.WithLabelValues(...)` being called without a terminal `.Set(1)` in both `evictPod` and `deletePod`, so pod eviction/deletion errors were never actually recorded on the `shredder_pod_errors_total` gauge despite the metric being registered and queried by the dashboard.
 
## Related Issue
Fixes #4 

## Motivation and Context
The dashboard gives users an out-of-the-box way to visualize k8s-shredder's Prometheus metrics without hand-building Grafana panels, matching how the chart already supports PodMonitor for scraping. While validating the dashboard's "Pod Errors" panel against the code path, found that `shredder_pod_errors_total` was never actually being set on failure, only created with a zero-value default — this fixes that gap so the panel reflects real eviction/deletion failures.

## How Has This Been Tested?

- `helm lint ./charts/k8s-shredder` — 0 failures.
- `helm template` with `grafanaDashboard.enabled=true` and `grafanaDatasource.enabled=true` — renders without error; verified the embedded dashboard JSON survives the ConfigMap round-trip and still parses as valid JSON with all panels/queries intact.
- Cross-checked every PromQL metric name referenced in the dashboard JSON against `pkg/metrics/metrics.go` — all resolve to real, registered metrics (no typos).
- Verified `WithLabelValues(...)` positional argument order matches each metric's declared label order for the three label-vector metrics used in the dashboard (`shredder_node_force_to_evict_time`, `shredder_pod_force_to_evict_time`, `shredder_pod_errors_total`).
- Deployed against a local kind cluster with kube-prometheus-stack (`podMonitor.enabled=true`, `EnableKarpenterDriftDetection=true`/`EnableKarpenterDisruptionDetection=true`) and confirmed metrics flow end-to-end into Grafana panels.
 
## Screenshots (if appropriate):

<img width="1476" height="737" alt="image" src="https://github.com/user-attachments/assets/00983a95-ebdb-4cdf-8aca-705842ad00cf" />

<img width="1531" height="894" alt="image" src="https://github.com/user-attachments/assets/9afac46e-36cc-4f8b-9e71-f63a77522b5e" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
