### PR TITLE
Feature leader election implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,29 @@ The following options can be used to customize the k8s-shredder controller:
 | ExtraParkingLabels                 | {}                                                          | (Optional) Map of extra labels to apply to nodes and pods during parking. Example: `{ "example.com/owner": "infrastructure" }` |
 | EvictionSafetyCheck                | true                                                        | Controls whether to perform safety checks before force eviction. If true, nodes will be unparked if pods don't have required parking labels. |
 | ParkingReasonLabel                 | "shredder.ethos.adobe.net/parked-reason"                   | Label used to track why a node or pod was parked (values: node-label, karpenter-drifted, karpenter-disrupted) |
+| EnableLeaderElection               | false                                                        | Enables Kubernetes lease-based leader election so only one controller instance runs the scheduler loop at a time. |
+| LeaderElectionLockName             | "k8s-shredder-leader-election"                              | Name of the Lease resource used for leader election. |
+| LeaderElectionNamespace            | ""                                                          | Namespace for the leader-election Lease. If empty, the controller uses the default namespace. |
+| LeaderElectionID                   | ""                                                          | Optional custom identity for the controller instance. If empty, a hostname-based value is generated automatically. |
+| LeaderElectionLeaseDuration        | 15s                                                         | How long a leader lease remains valid when the leader is not renewing it. |
+| LeaderElectionRenewDeadline        | 10s                                                         | How long the leader has to renew the lease before it is considered stale. |
+| LeaderElectionRetryPeriod          | 2s                                                          | How often the controller retries leader election when no leader is currently holding the lease. |
 
 ### How it works
 
 k8s-shredder will periodically run eviction loops, based on configured `EvictionLoopInterval`, trying to clean up all the pods from the parked nodes. Once all the pods are cleaned up, [cluster-autoscaler](
 
 https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) or [karpenter](https://github.com/kubernetes-sigs/karpenter) should chime in and recycle the parked node.
+
+#### Leader election behavior
+
+Before this change, every controller replica could start its own scheduler loop and attempt to process parked nodes concurrently. That could lead to duplicate eviction work and race conditions when multiple replicas handled the same workload.
+
+With leader election enabled by default, only one replica holds a Kubernetes Lease and runs the scheduler loop. The other replicas remain idle until leadership changes. If the current leader stops renewing the lease or exits, another replica can acquire leadership automatically and continue the work without manual intervention. This makes multi-replica deployments safer and avoids duplicate scheduling activity.
+
+To disable the behavior for single-replica deployments, set `EnableLeaderElection: false` in the configuration.
+
+By default, the EnableLeaderElection configuration is set to false. If the replica count is greater than 1, set this configuration to true.
 
 The diagram below describes a simple flow about how k8s-shredder handles stateful set applications:
 

--- a/charts/k8s-shredder/Chart.yaml
+++ b/charts/k8s-shredder/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   - name: sfotony
     email: gosselin@adobe.com
     url: https://adobe.com
-version: 0.2.8
+version: 0.2.9
 appVersion: v0.3.8

--- a/charts/k8s-shredder/README.md
+++ b/charts/k8s-shredder/README.md
@@ -1,6 +1,6 @@
 # k8s-shredder
 
-![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.8](https://img.shields.io/badge/AppVersion-v0.3.8-informational?style=flat-square)
+![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.8](https://img.shields.io/badge/AppVersion-v0.3.8-informational?style=flat-square)
 
 a novel way of dealing with kubernetes nodes blocked from draining
 

--- a/charts/k8s-shredder/templates/cluster-role.yaml
+++ b/charts/k8s-shredder/templates/cluster-role.yaml
@@ -21,4 +21,7 @@ rules:
 - apiGroups: [ "karpenter.sh" ]
   resources: [ nodeclaims ]
   verbs: [ get, list, watch ]
+- apiGroups: [ "coordination.k8s.io" ]
+  resources: [ leases ]
+  verbs: [ get, list, watch, create, update, patch ]
 {{ end }}

--- a/charts/k8s-shredder/templates/configmap.yaml
+++ b/charts/k8s-shredder/templates/configmap.yaml
@@ -34,3 +34,10 @@ data:
     EvictionSafetyCheck: {{.Values.shredder.EvictionSafetyCheck}}
     ParkingReasonLabel: "{{.Values.shredder.ParkingReasonLabel}}"
     ExtraParkingLabels: {{.Values.shredder.ExtraParkingLabels | toJson}}
+    EnableLeaderElection: {{.Values.shredder.EnableLeaderElection}}
+    LeaderElectionLockName: "{{.Values.shredder.LeaderElectionLockName}}"
+    LeaderElectionNamespace: "{{.Values.shredder.LeaderElectionNamespace}}"
+    LeaderElectionID: "{{.Values.shredder.LeaderElectionID}}"
+    LeaderElectionLeaseDuration: "{{.Values.shredder.LeaderElectionLeaseDuration}}"
+    LeaderElectionRenewDeadline: "{{.Values.shredder.LeaderElectionRenewDeadline}}"
+    LeaderElectionRetryPeriod: "{{.Values.shredder.LeaderElectionRetryPeriod}}"

--- a/charts/k8s-shredder/values.yaml
+++ b/charts/k8s-shredder/values.yaml
@@ -78,6 +78,20 @@ shredder:
     # example.com/owner: "infrastructure"
     # example.com/maintenance: "true"
 # -- RBAC (Role-Based Access Control) configuration
+  # -- Enable leader election so only one instance runs the eviction loop
+  EnableLeaderElection: false
+  # -- Name of the Lease object used for leader election
+  LeaderElectionLockName: k8s-shredder-leader-election
+  # -- Namespace where the Lease object will be created (default from POD_NAMESPACE or 'default')
+  LeaderElectionNamespace: ""
+  # -- Identity used for leader election; default is pod hostname if empty
+  LeaderElectionID: ""
+  # -- Lease duration for leader election
+  LeaderElectionLeaseDuration: 15s
+  # -- Renew deadline for leader election
+  LeaderElectionRenewDeadline: 10s
+  # -- Retry period between leader election attempts
+  LeaderElectionRetryPeriod: 2s
 rbac:
   # -- Create RBAC resources (ClusterRole, ClusterRoleBinding)
   create: true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 package cmd
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"time"
@@ -130,6 +131,13 @@ func discoverConfig() {
 	viper.SetDefault("ParkingReasonLabel", "shredder.ethos.adobe.net/parked-reason")
 	viper.SetDefault("EvictionLoopSchedule", "")
 	viper.SetDefault("EvictionLoopDuration", "")
+	viper.SetDefault("EnableLeaderElection", false)
+	viper.SetDefault("LeaderElectionLockName", "k8s-shredder-leader-election")
+	viper.SetDefault("LeaderElectionNamespace", "")
+	viper.SetDefault("LeaderElectionID", "")
+	viper.SetDefault("LeaderElectionLeaseDuration", 15*time.Second)
+	viper.SetDefault("LeaderElectionRenewDeadline", 10*time.Second)
+	viper.SetDefault("LeaderElectionRetryPeriod", 2*time.Second)
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -192,6 +200,13 @@ func parseConfig() {
 		"ExtraParkingLabels":                 cfg.ExtraParkingLabels,
 		"EvictionSafetyCheck":                cfg.EvictionSafetyCheck,
 		"ParkingReasonLabel":                 cfg.ParkingReasonLabel,
+		"EnableLeaderElection":               cfg.EnableLeaderElection,
+		"LeaderElectionLockName":             cfg.LeaderElectionLockName,
+		"LeaderElectionNamespace":            cfg.LeaderElectionNamespace,
+		"LeaderElectionID":                   cfg.LeaderElectionID,
+		"LeaderElectionLeaseDuration":        cfg.LeaderElectionLeaseDuration.String(),
+		"LeaderElectionRenewDeadline":        cfg.LeaderElectionRenewDeadline.String(),
+		"LeaderElectionRetryPeriod":          cfg.LeaderElectionRetryPeriod.String(),
 		"EvictionLoopSchedule":               cfg.EvictionLoopSchedule,
 		"EvictionLoopDuration":               cfg.EvictionLoopDuration,
 	}).Info("Loaded configuration")
@@ -228,42 +243,78 @@ func preRun(cmd *cobra.Command, args []string) {
 }
 
 func run(cmd *cobra.Command, args []string) {
-	var err error
-	scheduler, err = gocron.NewScheduler(gocron.WithLocation(time.UTC))
-	defer func() { _ = scheduler.Shutdown() }()
+	startScheduler := func() error {
+		var err error
+		scheduler, err = gocron.NewScheduler(gocron.WithLocation(time.UTC))
+		if err != nil {
+			return err
+		}
 
-	if err != nil {
-		log.Fatalf("Failed to create scheduler: %s", err)
+		h := handler.NewHandler(appContext)
+
+		job, err := scheduler.NewJob(
+			gocron.DurationJob(
+				cfg.EvictionLoopInterval,
+			),
+			gocron.NewTask(
+				h.Run,
+			),
+			gocron.WithSingletonMode(gocron.LimitModeReschedule),
+		)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Configured scheduler job with ID: %s", job.ID())
+
+		activeJobs := make([]uuid.UUID, 0)
+		for _, j := range scheduler.Jobs() {
+			activeJobs = append(activeJobs, j.ID())
+		}
+		log.Infoln("Active jobs:", activeJobs)
+
+		scheduler.Start()
+		log.Info("Scheduler started, happy shredding!")
+		return nil
 	}
 
-	h := handler.NewHandler(appContext)
+	if appContext.Config.EnableLeaderElection {
+		leaderCtx, cancel := context.WithCancel(appContext.Context)
+		defer cancel()
 
-	job, err := scheduler.NewJob(
-		gocron.DurationJob(
-			cfg.EvictionLoopInterval,
-		),
-		gocron.NewTask(
-			h.Run,
-		),
-		gocron.WithSingletonMode(gocron.LimitModeReschedule),
-	)
-
-	if err != nil {
-		log.Fatalf("Failed to configure scheduler's job: %s", err)
+		err := appContext.RunLeaderElection(
+			leaderCtx,
+			appContext.K8sClient,
+			appContext.Config,
+			func() {
+				err := startScheduler()
+				if err != nil {
+					log.Fatalf("Failed to start scheduler as leader: %s", err)
+				}
+			},
+			func() {
+				log.Error("Leadership lost, shutting down")
+				cancel()
+			},
+		)
+		if err != nil {
+			log.Fatalf("Leader election failed: %s", err)
+		}
+	} else {
+		if err := startScheduler(); err != nil {
+			log.Fatalf("Failed to create scheduler: %s", err)
+		}
+		<-appContext.Context.Done()
 	}
 
-	// each job has a unique id
-	log.Infof("Configured scheduler job with ID: %s", job.ID())
-
-	activeJobs := make([]uuid.UUID, 0)
-	for _, j := range scheduler.Jobs() {
-		activeJobs = append(activeJobs, j.ID())
+	if scheduler != nil {
+		if err := scheduler.StopJobs(); err != nil {
+			log.Errorf("Failed to stop running jobs: %s", err)
+		}
+		if err := scheduler.Shutdown(); err != nil {
+			log.Errorf("Failed to shutdown scheduler: %s", err)
+		}
 	}
-	log.Infoln("Active jobs:", activeJobs)
-
-	scheduler.Start()
-	log.Info("Scheduler started, happy shredding!")
-	select {}
 }
 
 func reset() {

--- a/config.yaml
+++ b/config.yaml
@@ -44,3 +44,10 @@ EvictionSafetyCheck: true  # Controls whether to perform safety checks before fo
 
 # Parking reason tracking
 ParkingReasonLabel: shredder.ethos.adobe.net/parked-reason  # Label used to track why a node or pod was parked
+EnableLeaderElection: false
+LeaderElectionLockName: k8s-shredder-leader-election
+LeaderElectionNamespace: k8s-shredder
+LeaderElectionID: ""  # Will auto-detect from pod hostname
+LeaderElectionLeaseDuration: 15s
+LeaderElectionRenewDeadline: 10s
+LeaderElectionRetryPeriod: 2s

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,11 @@
 # Architecture
 
 <p align="left"><img src="https://lucid.app/publicSegments/view/b6059d9c-d180-40b8-9e85-dd995c44b8cc/image.png" width="70%" /></p>
+
+## Leader election flow
+
+Before leader election was introduced, each controller replica could start its own scheduler loop and attempt to manage parked nodes independently. In a multi-replica deployment that meant duplicate eviction work and possible coordination issues when several instances tried to process the same resources.
+
+The current implementation uses Kubernetes Lease-based leader election to ensure that only one replica actively runs the scheduler. The elected leader performs parking and eviction operations while the other replicas wait for leadership to change. If the leader exits or loses the lease, another replica can take over automatically. This keeps the behavior deterministic and avoids duplicate work in HA deployments.
+
+The relevant configuration knobs are `EnableLeaderElection`, `LeaderElectionLockName`, `LeaderElectionNamespace`, `LeaderElectionID`, `LeaderElectionLeaseDuration`, `LeaderElectionRenewDeadline`, and `LeaderElectionRetryPeriod`.

--- a/internal/testing/local_env_prep_helm.sh
+++ b/internal/testing/local_env_prep_helm.sh
@@ -67,6 +67,7 @@ kubectl apply -f "${test_dir}/prometheus_stuffs.yaml"
 
 echo "KIND: deploying Argo Rollouts CRD..."
 kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/rollout-crd.yaml
+kubectl wait --for condition=established --timeout=60s crd/rollouts.argoproj.io
 
 echo "KIND: deploying test applications..."
 kubectl apply -f "${test_dir}/test_apps.yaml"

--- a/internal/testing/local_env_prep_karpenter_helm.sh
+++ b/internal/testing/local_env_prep_karpenter_helm.sh
@@ -142,6 +142,7 @@ kubectl apply -f "${test_dir}/prometheus_stuffs_karpenter.yaml"
 
 echo "KIND: deploying Argo Rollouts CRD..."
 kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/rollout-crd.yaml
+kubectl wait --for condition=established --timeout=60s crd/rollouts.argoproj.io
 
 echo "KIND: deploying test applications..."
 kubectl apply -f "${test_dir}/test_apps.yaml"

--- a/internal/testing/local_env_prep_node_labels_helm.sh
+++ b/internal/testing/local_env_prep_node_labels_helm.sh
@@ -73,6 +73,7 @@ kubectl apply -f "${test_dir}/prometheus_stuffs_node_labels.yaml"
 
 echo "KIND: deploying Argo Rollouts CRD..."
 kubectl apply -f https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.7.2/manifests/crds/rollout-crd.yaml
+kubectl wait --for condition=established --timeout=60s crd/rollouts.argoproj.io
 
 echo "KIND: deploying test applications..."
 kubectl apply -f "${test_dir}/test_apps.yaml"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,20 @@ type Config struct {
 	EvictionSafetyCheck bool
 	// ParkingReasonLabel is the label used to track why a node or pod was parked
 	ParkingReasonLabel string
+	// EnableLeaderElection controls whether this instance participates in leader election
+	EnableLeaderElection bool
+	// LeaderElectionLockName is the name of the Lease lock resource used for leader election
+	LeaderElectionLockName string
+	// LeaderElectionNamespace is the namespace where the lock resource is created
+	LeaderElectionNamespace string
+	// LeaderElectionID is the identity used for leader election
+	LeaderElectionID string
+	// LeaderElectionLeaseDuration is the lease duration for leader election
+	LeaderElectionLeaseDuration time.Duration
+	// LeaderElectionRenewDeadline is the renew deadline for leader election
+	LeaderElectionRenewDeadline time.Duration
+	// LeaderElectionRetryPeriod is the retry period between leader election attempts
+	LeaderElectionRetryPeriod time.Duration
 }
 
 // GetEvictionLoopSchedule returns a parsed Schedule object if EvictionLoopSchedule is configured

--- a/pkg/utils/leader.go
+++ b/pkg/utils/leader.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/adobe/k8s-shredder/pkg/config"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+// RunLeaderElection starts the client-go leader election loop using the
+// configuration provided. It blocks until the provided context is done or
+// leader election stops. Callbacks `onStartedLeading` and `onStoppedLeading`
+// are invoked when leadership is acquired or lost respectively.
+func (ac *AppContext) RunLeaderElection(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	cfg config.Config,
+	onStartedLeading func(),
+	onStoppedLeading func(),
+) error {
+	id := cfg.LeaderElectionID
+	if id == "" {
+		hn, err := os.Hostname()
+		if err != nil {
+			return err
+		}
+		id = hn + "-" + uuid.New().String()
+	}
+
+	lockName := cfg.LeaderElectionLockName
+	lockNamespace := cfg.LeaderElectionNamespace
+	if lockNamespace == "" {
+		lockNamespace = "default"
+	}
+
+	// create the lock
+	rl, err := resourcelock.New(resourcelock.LeasesResourceLock, lockNamespace, lockName,
+		kubeClient.CoreV1(), kubeClient.CoordinationV1(), resourcelock.ResourceLockConfig{
+			Identity: id,
+		})
+	if err != nil {
+		return err
+	}
+
+	lec := leaderelection.LeaderElectionConfig{
+		Lock:            rl,
+		LeaseDuration:   cfg.LeaderElectionLeaseDuration,
+		RenewDeadline:   cfg.LeaderElectionRenewDeadline,
+		RetryPeriod:     cfg.LeaderElectionRetryPeriod,
+		ReleaseOnCancel: true,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				log.Infof("Became leader (id=%s)", id)
+				if onStartedLeading != nil {
+					onStartedLeading()
+				}
+			},
+			OnStoppedLeading: func() {
+				log.Infof("Stopped being leader (id=%s)", id)
+				if onStoppedLeading != nil {
+					onStoppedLeading()
+				}
+			},
+			OnNewLeader: func(identity string) {
+				if identity == id {
+					// we are the leader
+					return
+				}
+				log.Infof("New leader elected: %s", identity)
+			},
+		},
+	}
+
+	elector, err := leaderelection.NewLeaderElector(lec)
+	if err != nil {
+		return err
+	}
+
+	// Run blocks until ctx is done or leader election loop exits
+	elector.Run(ctx)
+
+	// give a tiny grace period to let callbacks finish
+	select {
+	case <-time.After(100 * time.Millisecond):
+	case <-ctx.Done():
+	}
+
+	return nil
+}

--- a/pkg/utils/leader_test.go
+++ b/pkg/utils/leader_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/adobe/k8s-shredder/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// fastLeaderElectionConfig returns timing values that are fast enough to keep
+// unit tests short while still satisfying leaderelection.NewLeaderElector's
+// validation constraints (LeaseDuration > RenewDeadline > RetryPeriod*JitterFactor).
+func fastLeaderElectionConfig() config.Config {
+	return config.Config{
+		LeaderElectionLockName:      "test-lock",
+		LeaderElectionLeaseDuration: 400 * time.Millisecond,
+		LeaderElectionRenewDeadline: 200 * time.Millisecond,
+		LeaderElectionRetryPeriod:   50 * time.Millisecond,
+	}
+}
+
+func TestRunLeaderElection_BecomesLeaderAndStops(t *testing.T) {
+	cfg := fastLeaderElectionConfig()
+	cfg.LeaderElectionID = "test-identity"
+
+	fakeClient := fake.NewClientset()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ac := &AppContext{}
+
+	var startedLeading, stoppedLeading atomic.Bool
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ac.RunLeaderElection(ctx, fakeClient, cfg,
+			func() { startedLeading.Store(true) },
+			func() { stoppedLeading.Store(true) },
+		)
+	}()
+
+	require.Eventually(t, startedLeading.Load, 2*time.Second, 10*time.Millisecond, "expected to become leader")
+
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunLeaderElection did not return after context cancellation")
+	}
+
+	assert.True(t, stoppedLeading.Load(), "expected onStoppedLeading to be called")
+}
+
+func TestRunLeaderElection_UsesConfiguredIdentity(t *testing.T) {
+	cfg := fastLeaderElectionConfig()
+	cfg.LeaderElectionID = "my-custom-identity"
+	cfg.LeaderElectionNamespace = "custom-ns"
+
+	fakeClient := fake.NewClientset()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ac := &AppContext{}
+
+	var started atomic.Bool
+	done := make(chan error, 1)
+	go func() {
+		done <- ac.RunLeaderElection(ctx, fakeClient, cfg, func() { started.Store(true) }, nil)
+	}()
+
+	require.Eventually(t, started.Load, 2*time.Second, 10*time.Millisecond, "expected to become leader")
+
+	lease, err := fakeClient.CoordinationV1().Leases("custom-ns").Get(context.Background(), cfg.LeaderElectionLockName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, lease.Spec.HolderIdentity)
+	assert.Equal(t, cfg.LeaderElectionID, *lease.Spec.HolderIdentity)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunLeaderElection did not return after context cancellation")
+	}
+}
+
+func TestRunLeaderElection_DefaultsNamespaceWhenEmpty(t *testing.T) {
+	cfg := fastLeaderElectionConfig()
+	cfg.LeaderElectionID = "identity-default-ns"
+	cfg.LeaderElectionNamespace = ""
+
+	fakeClient := fake.NewClientset()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ac := &AppContext{}
+
+	var started atomic.Bool
+	done := make(chan error, 1)
+	go func() {
+		done <- ac.RunLeaderElection(ctx, fakeClient, cfg, func() { started.Store(true) }, nil)
+	}()
+
+	require.Eventually(t, started.Load, 2*time.Second, 10*time.Millisecond, "expected to become leader")
+
+	_, err := fakeClient.CoordinationV1().Leases("default").Get(context.Background(), cfg.LeaderElectionLockName, metav1.GetOptions{})
+	assert.NoError(t, err, "expected lease to be created in the default namespace")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunLeaderElection did not return after context cancellation")
+	}
+}
+
+func TestRunLeaderElection_GeneratesIdentityWhenNotConfigured(t *testing.T) {
+	cfg := fastLeaderElectionConfig()
+	cfg.LeaderElectionID = ""
+
+	fakeClient := fake.NewClientset()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ac := &AppContext{}
+
+	var started atomic.Bool
+	done := make(chan error, 1)
+	go func() {
+		done <- ac.RunLeaderElection(ctx, fakeClient, cfg, func() { started.Store(true) }, nil)
+	}()
+
+	require.Eventually(t, started.Load, 2*time.Second, 10*time.Millisecond, "expected to become leader")
+
+	lease, err := fakeClient.CoordinationV1().Leases("default").Get(context.Background(), cfg.LeaderElectionLockName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, lease.Spec.HolderIdentity)
+	assert.NotEmpty(t, *lease.Spec.HolderIdentity)
+	// generated identity is "<hostname>-<uuid>"
+	assert.True(t, strings.Contains(*lease.Spec.HolderIdentity, "-"), "expected generated identity to contain a hostname/uuid separator")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunLeaderElection did not return after context cancellation")
+	}
+}
+
+func TestRunLeaderElection_NilCallbacksDoNotPanic(t *testing.T) {
+	cfg := fastLeaderElectionConfig()
+	cfg.LeaderElectionID = "identity-nil-callbacks"
+
+	fakeClient := fake.NewClientset()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ac := &AppContext{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ac.RunLeaderElection(ctx, fakeClient, cfg, nil, nil)
+	}()
+
+	require.Eventually(t, func() bool {
+		_, err := fakeClient.CoordinationV1().Leases("default").Get(context.Background(), cfg.LeaderElectionLockName, metav1.GetOptions{})
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond, "expected lease to be created")
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunLeaderElection did not return after context cancellation")
+	}
+}


### PR DESCRIPTION
## Description

This change adds Kubernetes Lease-based leader election to k8s-shredder so that only one controller replica actively runs the scheduler loop at a time.

The new leader-election flow is wired through leader.go:20-89 and controlled from root.go:281-301. When EnableLeaderElection is enabled, the application uses a Kubernetes Lease lock to elect a single leader. The elected leader starts the eviction scheduler, while the remaining replicas wait for leadership to change. If the current leader loses the lease or exits, another replica can take over automatically.

This resolves the previous HA behavior where every replica could start the node parking workflow at the same time, leading to duplicate processing of the same parked-node events and potential race conditions.

## Related Issue

Fixes #3 

## Motivation and Context

Before this change, all k8s-shredder pods could start their own scheduler loop and attempt to process parked-node events concurrently. In a multi-replica deployment, that meant duplicate eviction work and possible coordination issues when several replicas tried to manage the same resources.

This implementation introduces configurable leadership settings in config.go:78-91, config.yaml:47-54, and the Helm chart values in values.yaml:81-94, so the behavior can be turned on for HA deployments without changing the existing workflow for single-replica setups.

## How Has This Been Tested?

Tested the node parking workflow using the `NodeLabelsToDetect` configuration in `values.yaml` (or `config.yaml`) with the `maintenance=true` node label.
* Verified that when a node was labeled with `maintenance=true`, **k8s-shredder** automatically detected the node and initiated the parking workflow.
* Confirmed that the node and its corresponding pods were automatically marked as parked without requiring any manual parking labels.
* The node was parked and its pods are evicted successfully to healthy node in the cluster.

Additional Testing
* Tested the node parking workflow using the `kubectl cordon` command.
* Manually marked the node and its pods as parked. Then the pods are evicted to healthy node in the cluster.

## Screenshots (if appropriate):
<img width="1277" height="384" alt="image" src="https://github.com/user-attachments/assets/e90c60fd-757b-42d4-afe0-a5bc7c663b4e" />
<img width="1261" height="459" alt="image" src="https://github.com/user-attachments/assets/c43b0d13-889e-4fa5-9557-49e7e02c06c1" />
<img width="1263" height="346" alt="image" src="https://github.com/user-attachments/assets/22729df4-2c07-4f84-89d1-92be58d6576e" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
